### PR TITLE
🔀 :: 35-유저id binary(16)으로 변경

### DIFF
--- a/src/main/kotlin/com/msg/gcms/domain/user/domain/entity/User.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/user/domain/entity/User.kt
@@ -10,6 +10,7 @@ import javax.persistence.*
 @Entity
 class User(
     @Id
+    @Column(columnDefinition = "BINARY(16)")
     var id: UUID,
 
     @Column(length = 20)


### PR DESCRIPTION
## 💡 개요
* 유저 id가 uuid라 binary(16)으로 지정해야됨

## 📃 작업내용
* 유저 id binary(16)으로 지정

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
