### PR TITLE
🔀 :: 44-동아리 신청 마감 API

### DIFF
--- a/src/main/kotlin/com/msg/gcms/domain/club/presentation/ClubController.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/presentation/ClubController.kt
@@ -13,6 +13,7 @@ import javax.validation.Valid
 import com.msg.gcms.domain.club.enums.ClubType
 import com.msg.gcms.domain.club.presentation.data.request.UpdateClubRequest
 import com.msg.gcms.domain.club.presentation.data.response.ClubListResponseDto
+import com.msg.gcms.domain.club.service.CloseClubService
 import com.msg.gcms.domain.club.service.FindClubListService
 import com.msg.gcms.domain.club.service.UpdateClubService
 import org.springframework.web.bind.annotation.GetMapping
@@ -27,6 +28,7 @@ class ClubController(
     private val createClubService: CreateClubService,
     private val findClubListService: FindClubListService,
     private val updateClubService: UpdateClubService,
+    private val closeClubService: CloseClubService,
     private val clubConverter: ClubConverter
 ) {
     @PostMapping
@@ -45,5 +47,10 @@ class ClubController(
     fun updateClubById(@PathVariable club_id: Long, @Valid @RequestBody updateClubRequest: UpdateClubRequest): ResponseEntity<Void> =
         clubConverter.toDto(updateClubRequest)
             .let { updateClubService.execute(club_id, it) }
+            .let { ResponseEntity.noContent().build() }
+
+    @PatchMapping("/{club_id}/close")
+    fun closeClub(@PathVariable club_id: Long): ResponseEntity<Void> =
+        closeClubService.execute(club_id)
             .let { ResponseEntity.noContent().build() }
 }

--- a/src/main/kotlin/com/msg/gcms/domain/club/presentation/data/dto/ClubStatusDto.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/presentation/data/dto/ClubStatusDto.kt
@@ -1,0 +1,5 @@
+package com.msg.gcms.domain.club.presentation.data.dto
+
+class ClubStatusDto(
+    val isOpened: Boolean
+)

--- a/src/main/kotlin/com/msg/gcms/domain/club/service/CloseClubService.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/service/CloseClubService.kt
@@ -1,5 +1,7 @@
 package com.msg.gcms.domain.club.service
 
+import com.msg.gcms.domain.club.presentation.data.dto.ClubStatusDto
+
 interface CloseClubService {
-    fun execute(clubId: Long)
+    fun execute(clubId: Long): ClubStatusDto
 }

--- a/src/main/kotlin/com/msg/gcms/domain/club/service/CloseClubService.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/service/CloseClubService.kt
@@ -1,0 +1,5 @@
+package com.msg.gcms.domain.club.service
+
+interface CloseClubService {
+    fun execute(clubId: Long)
+}

--- a/src/main/kotlin/com/msg/gcms/domain/club/service/impl/CloseClubServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/service/impl/CloseClubServiceImpl.kt
@@ -4,7 +4,9 @@ import com.msg.gcms.domain.club.domain.entity.Club
 import com.msg.gcms.domain.club.domain.repository.ClubRepository
 import com.msg.gcms.domain.club.exception.ClubNotFoundException
 import com.msg.gcms.domain.club.exception.HeadNotSameException
+import com.msg.gcms.domain.club.presentation.data.dto.ClubStatusDto
 import com.msg.gcms.domain.club.service.CloseClubService
+import com.msg.gcms.domain.club.utils.ClubConverter
 import com.msg.gcms.global.util.UserUtil
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -13,9 +15,10 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(rollbackFor = [Exception::class])
 class CloseClubServiceImpl(
     private val userUtil: UserUtil,
-    private val clubRepository: ClubRepository
+    private val clubRepository: ClubRepository,
+    private val clubConverter: ClubConverter,
 ) : CloseClubService {
-    override fun execute(clubId: Long) {
+    override fun execute(clubId: Long): ClubStatusDto {
         val club = clubRepository.findById(clubId)
             .orElseThrow { throw ClubNotFoundException() }
         val user = userUtil.fetchCurrentUser()
@@ -37,6 +40,7 @@ class CloseClubServiceImpl(
             isOpened = false
         )
         clubRepository.save(newClub)
+        return clubConverter.toStatusDto(club)
     }
 
 }

--- a/src/main/kotlin/com/msg/gcms/domain/club/service/impl/CloseClubServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/service/impl/CloseClubServiceImpl.kt
@@ -24,6 +24,11 @@ class CloseClubServiceImpl(
         val user = userUtil.fetchCurrentUser()
         if (club.user != user)
             throw HeadNotSameException()
+        closeClub(club)
+        return clubConverter.toStatusDto(club)
+    }
+
+    private fun closeClub(club: Club) {
         val newClub = Club(
             id = club.id,
             activityImg = club.activityImg,
@@ -40,7 +45,6 @@ class CloseClubServiceImpl(
             isOpened = false
         )
         clubRepository.save(newClub)
-        return clubConverter.toStatusDto(club)
     }
 
 }

--- a/src/main/kotlin/com/msg/gcms/domain/club/service/impl/CloseClubServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/service/impl/CloseClubServiceImpl.kt
@@ -1,0 +1,42 @@
+package com.msg.gcms.domain.club.service.impl
+
+import com.msg.gcms.domain.club.domain.entity.Club
+import com.msg.gcms.domain.club.domain.repository.ClubRepository
+import com.msg.gcms.domain.club.exception.ClubNotFoundException
+import com.msg.gcms.domain.club.exception.HeadNotSameException
+import com.msg.gcms.domain.club.service.CloseClubService
+import com.msg.gcms.global.util.UserUtil
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(rollbackFor = [Exception::class])
+class CloseClubServiceImpl(
+    private val userUtil: UserUtil,
+    private val clubRepository: ClubRepository
+) : CloseClubService {
+    override fun execute(clubId: Long) {
+        val club = clubRepository.findById(clubId)
+            .orElseThrow { throw ClubNotFoundException() }
+        val user = userUtil.fetchCurrentUser()
+        if (club.user != user)
+            throw HeadNotSameException()
+        val newClub = Club(
+            id = club.id,
+            activityImg = club.activityImg,
+            applicant = club.applicant,
+            bannerImg = club.bannerImg,
+            clubMember = club.clubMember,
+            contact = club.contact,
+            content = club.content,
+            name = club.name,
+            notionLink = club.notionLink,
+            teacher = club.teacher,
+            type = club.type,
+            user = club.user,
+            isOpened = false
+        )
+        clubRepository.save(newClub)
+    }
+
+}

--- a/src/main/kotlin/com/msg/gcms/domain/club/utils/ClubConverter.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/utils/ClubConverter.kt
@@ -6,6 +6,7 @@ import com.msg.gcms.domain.club.presentation.data.request.CreateClubRequest
 import com.msg.gcms.domain.user.domain.entity.User
 import com.msg.gcms.domain.club.enums.ClubType
 import com.msg.gcms.domain.club.presentation.data.dto.ClubListDto
+import com.msg.gcms.domain.club.presentation.data.dto.ClubStatusDto
 import com.msg.gcms.domain.club.presentation.data.dto.ClubTypeDto
 import com.msg.gcms.domain.club.presentation.data.request.UpdateClubRequest
 import com.msg.gcms.domain.club.presentation.data.response.ClubListResponseDto
@@ -17,4 +18,5 @@ interface ClubConverter {
     fun toDto(club: Club): ClubListDto
     fun toResponseDto(dto: ClubListDto): ClubListResponseDto
     fun toDto(updateClubRequest: UpdateClubRequest): ClubDto
+    fun toStatusDto(club: Club): ClubStatusDto
 }

--- a/src/main/kotlin/com/msg/gcms/domain/club/utils/impl/ClubConverterImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/utils/impl/ClubConverterImpl.kt
@@ -7,6 +7,7 @@ import com.msg.gcms.domain.club.utils.ClubConverter
 import com.msg.gcms.domain.user.domain.entity.User
 import com.msg.gcms.domain.club.enums.ClubType
 import com.msg.gcms.domain.club.presentation.data.dto.ClubListDto
+import com.msg.gcms.domain.club.presentation.data.dto.ClubStatusDto
 import com.msg.gcms.domain.club.presentation.data.dto.ClubTypeDto
 import com.msg.gcms.domain.club.presentation.data.request.UpdateClubRequest
 import com.msg.gcms.domain.club.presentation.data.response.ClubListResponseDto
@@ -52,6 +53,9 @@ class ClubConverterImpl : ClubConverter {
 
     override fun toResponseDto(dto: ClubListDto): ClubListResponseDto =
         ClubListResponseDto(id = dto.id, type = dto.type, name = dto.name, bannerImg = dto.bannerImg)
+
+    override fun toStatusDto(club: Club): ClubStatusDto =
+        ClubStatusDto(club.isOpened)
 
     override fun toDto(updateClubRequest: UpdateClubRequest): ClubDto =
         ClubDto(

--- a/src/main/kotlin/com/msg/gcms/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/msg/gcms/global/security/SecurityConfig.kt
@@ -42,7 +42,8 @@ class SecurityConfig(
 
             .antMatchers(HttpMethod.POST, "/club").authenticated()
             .antMatchers(HttpMethod.GET, "/club").permitAll()
-            .antMatchers(HttpMethod.PATCH, "/club/{clubId}").authenticated()
+            .antMatchers(HttpMethod.PATCH, "/club/{club_id}").authenticated()
+            .antMatchers(HttpMethod.PATCH, "/club/{club_id}/close").authenticated()
 
             .antMatchers(HttpMethod.GET,"/user").authenticated()
 

--- a/src/test/kotlin/com/msg/gcms/domain/club/controller/CloseClubControllerTest.kt
+++ b/src/test/kotlin/com/msg/gcms/domain/club/controller/CloseClubControllerTest.kt
@@ -1,0 +1,45 @@
+package com.msg.gcms.domain.club.controller
+
+import com.msg.gcms.domain.club.enums.ClubType
+import com.msg.gcms.domain.club.presentation.ClubController
+import com.msg.gcms.domain.club.presentation.data.dto.ClubDto
+import com.msg.gcms.domain.club.presentation.data.request.UpdateClubRequest
+import com.msg.gcms.domain.club.service.CloseClubService
+import com.msg.gcms.domain.club.service.CreateClubService
+import com.msg.gcms.domain.club.service.FindClubListService
+import com.msg.gcms.domain.club.service.UpdateClubService
+import com.msg.gcms.domain.club.utils.ClubConverter
+import com.msg.gcms.domain.club.utils.impl.ClubConverterImpl
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.context.annotation.Bean
+import org.springframework.http.HttpStatus
+
+class CloseClubControllerTest : BehaviorSpec({
+    @Bean
+    fun clubConverter(): ClubConverter {
+        return ClubConverterImpl()
+    }
+    val findClubListService = mockk<FindClubListService>()
+    val createClubService = mockk<CreateClubService>()
+    val updateClubService = mockk<UpdateClubService>()
+    val closeClubService = mockk<CloseClubService>()
+    val clubController = ClubController(createClubService, findClubListService, updateClubService, closeClubService, clubConverter())
+
+    given("요청이 들어오면") {
+        `when`("is received") {
+            every { closeClubService.execute(1) } returns Unit
+            val response = clubController.closeClub(1)
+
+            then("서비스가 한번은 실행되어야 함") {
+                verify(exactly = 1) { closeClubService.execute(1) }
+            }
+            then("response status should be no content") {
+                response.statusCode shouldBe HttpStatus.NO_CONTENT
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/msg/gcms/domain/club/controller/CloseClubControllerTest.kt
+++ b/src/test/kotlin/com/msg/gcms/domain/club/controller/CloseClubControllerTest.kt
@@ -3,6 +3,7 @@ package com.msg.gcms.domain.club.controller
 import com.msg.gcms.domain.club.enums.ClubType
 import com.msg.gcms.domain.club.presentation.ClubController
 import com.msg.gcms.domain.club.presentation.data.dto.ClubDto
+import com.msg.gcms.domain.club.presentation.data.dto.ClubStatusDto
 import com.msg.gcms.domain.club.presentation.data.request.UpdateClubRequest
 import com.msg.gcms.domain.club.service.CloseClubService
 import com.msg.gcms.domain.club.service.CreateClubService
@@ -31,7 +32,7 @@ class CloseClubControllerTest : BehaviorSpec({
 
     given("요청이 들어오면") {
         `when`("is received") {
-            every { closeClubService.execute(1) } returns Unit
+            every { closeClubService.execute(1) } returns ClubStatusDto(false)
             val response = clubController.closeClub(1)
 
             then("서비스가 한번은 실행되어야 함") {

--- a/src/test/kotlin/com/msg/gcms/domain/club/controller/CreateClubControllerTest.kt
+++ b/src/test/kotlin/com/msg/gcms/domain/club/controller/CreateClubControllerTest.kt
@@ -4,6 +4,7 @@ import com.msg.gcms.domain.club.enums.ClubType
 import com.msg.gcms.domain.club.presentation.ClubController
 import com.msg.gcms.domain.club.presentation.data.dto.ClubDto
 import com.msg.gcms.domain.club.presentation.data.request.CreateClubRequest
+import com.msg.gcms.domain.club.service.CloseClubService
 import com.msg.gcms.domain.club.service.CreateClubService
 import com.msg.gcms.domain.club.service.FindClubListService
 import com.msg.gcms.domain.club.service.UpdateClubService
@@ -33,7 +34,8 @@ class CreateClubControllerTest : BehaviorSpec({
     val findClubListService = mockk<FindClubListService>()
     val createClubService = mockk<CreateClubService>()
     val updateClubService = mockk<UpdateClubService>()
-    val clubController = ClubController(createClubService, findClubListService, updateClubService, clubConverter())
+    val closeClubService = mockk<CloseClubService>()
+    val clubController = ClubController(createClubService, findClubListService, updateClubService, closeClubService,clubConverter())
 
     given("요청이 들어오면") {
         val dto = ClubDto(

--- a/src/test/kotlin/com/msg/gcms/domain/club/controller/FindClubListControllerTest.kt
+++ b/src/test/kotlin/com/msg/gcms/domain/club/controller/FindClubListControllerTest.kt
@@ -5,6 +5,7 @@ import com.msg.gcms.domain.club.presentation.ClubController
 import com.msg.gcms.domain.club.presentation.data.dto.ClubListDto
 import com.msg.gcms.domain.club.presentation.data.dto.ClubTypeDto
 import com.msg.gcms.domain.club.presentation.data.response.ClubListResponseDto
+import com.msg.gcms.domain.club.service.CloseClubService
 import com.msg.gcms.domain.club.service.CreateClubService
 import com.msg.gcms.domain.club.service.FindClubListService
 import com.msg.gcms.domain.club.service.impl.UpdateClubServiceImpl
@@ -28,7 +29,8 @@ class FindClubListControllerTest : BehaviorSpec({
     val findClubListService = mockk<FindClubListService>()
     val createClubService = mockk<CreateClubService>()
     val updateClubService = mockk<UpdateClubServiceImpl>()
-    val clubController = ClubController(createClubService, findClubListService, updateClubService, clubConverter())
+    val closeClubService = mockk<CloseClubService>()
+    val clubController = ClubController(createClubService, findClubListService, updateClubService, closeClubService,clubConverter())
 
     given("find club list request") {
         val type = ClubType.values().random()

--- a/src/test/kotlin/com/msg/gcms/domain/club/controller/UpdateClubControllerTest.kt
+++ b/src/test/kotlin/com/msg/gcms/domain/club/controller/UpdateClubControllerTest.kt
@@ -4,6 +4,7 @@ import com.msg.gcms.domain.club.enums.ClubType
 import com.msg.gcms.domain.club.presentation.ClubController
 import com.msg.gcms.domain.club.presentation.data.dto.ClubDto
 import com.msg.gcms.domain.club.presentation.data.request.UpdateClubRequest
+import com.msg.gcms.domain.club.service.CloseClubService
 import com.msg.gcms.domain.club.service.CreateClubService
 import com.msg.gcms.domain.club.service.FindClubListService
 import com.msg.gcms.domain.club.service.UpdateClubService
@@ -26,7 +27,8 @@ class UpdateClubControllerTest : BehaviorSpec({
     val createClubService = mockk<CreateClubService>()
     val updateClubService = mockk<UpdateClubService>()
     val clubConverter = clubConverter()
-    val clubController = ClubController(createClubService, findClubListService, updateClubService, clubConverter)
+    val closeClubService = mockk<CloseClubService>()
+    val clubController = ClubController(createClubService, findClubListService, updateClubService, closeClubService,clubConverter())
 
     given("요청이 들어오면") {
         val dto = ClubDto(

--- a/src/test/kotlin/com/msg/gcms/domain/club/service/CloseClubServiceTest.kt
+++ b/src/test/kotlin/com/msg/gcms/domain/club/service/CloseClubServiceTest.kt
@@ -1,0 +1,54 @@
+package com.msg.gcms.domain.club.service
+
+import com.msg.gcms.domain.club.domain.entity.Club
+import com.msg.gcms.domain.club.domain.repository.ClubRepository
+import com.msg.gcms.domain.club.enums.ClubType
+import com.msg.gcms.domain.user.domain.entity.User
+import com.msg.gcms.domain.user.domain.repository.UserRepository
+import com.msg.gcms.global.security.jwt.JwtTokenProvider
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.security.core.context.SecurityContextHolder
+import java.util.*
+
+class CloseClubServiceTest : BehaviorSpec({
+    val closeClubService =  mockk<CloseClubService>(relaxed = true)
+    val tokenProvider = mockk<JwtTokenProvider>(relaxed = true)
+    val userRepository = mockk<UserRepository>()
+    val clubRepository = mockk<ClubRepository>()
+    extension(SpringExtension)
+    given("유저와 동아리가 있을때"){
+        val user = User(UUID.randomUUID(), "s21053@gsm.hs.kr", "test", 2, 1, 16, null, listOf(), listOf(), listOf())
+        every { userRepository.save(user) } returns user
+        val director = userRepository.save(user)
+        val directorToken = tokenProvider.generateAccessToken(director.email)
+        val authentication = tokenProvider.authentication(directorToken)
+        SecurityContextHolder.getContext().authentication = authentication
+        val club = Club(
+            id = 1,
+            name = "testClub",
+            content = "test",
+            bannerImg = "testImg",
+            notionLink = "",
+            contact = "010-0000-0000",
+            type = ClubType.FREEDOM,
+            isOpened = true,
+            user = director,
+            activityImg = listOf(),
+            applicant = listOf(),
+            clubMember = listOf(),
+            teacher = ""
+        )
+        every { clubRepository.save(club) } returns club
+        clubRepository.save(club)
+        `when`("서비스를 시작하면"){
+            closeClubService.execute(1)
+            then("update가 한번 실행되어야 됨"){
+                verify(exactly = 1) { clubRepository.save(club) }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/msg/gcms/domain/club/service/CloseClubServiceTest.kt
+++ b/src/test/kotlin/com/msg/gcms/domain/club/service/CloseClubServiceTest.kt
@@ -3,22 +3,25 @@ package com.msg.gcms.domain.club.service
 import com.msg.gcms.domain.club.domain.entity.Club
 import com.msg.gcms.domain.club.domain.repository.ClubRepository
 import com.msg.gcms.domain.club.enums.ClubType
+import com.msg.gcms.domain.club.presentation.data.dto.ClubStatusDto
 import com.msg.gcms.domain.user.domain.entity.User
 import com.msg.gcms.domain.user.domain.repository.UserRepository
 import com.msg.gcms.global.security.jwt.JwtTokenProvider
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.core.context.SecurityContextHolder
 import java.util.*
 
 class CloseClubServiceTest : BehaviorSpec({
-    val closeClubService =  mockk<CloseClubService>(relaxed = true)
     val tokenProvider = mockk<JwtTokenProvider>(relaxed = true)
     val userRepository = mockk<UserRepository>()
     val clubRepository = mockk<ClubRepository>()
+    val closeClubService =  mockk<CloseClubService>(relaxed = true)
     extension(SpringExtension)
     given("유저와 동아리가 있을때"){
         val user = User(UUID.randomUUID(), "s21053@gsm.hs.kr", "test", 2, 1, 16, null, listOf(), listOf(), listOf())
@@ -45,9 +48,12 @@ class CloseClubServiceTest : BehaviorSpec({
         every { clubRepository.save(club) } returns club
         clubRepository.save(club)
         `when`("서비스를 시작하면"){
-            closeClubService.execute(1)
+            val result = closeClubService.execute(1)
             then("update가 한번 실행되어야 됨"){
                 verify(exactly = 1) { clubRepository.save(club) }
+            }
+            then("isOpened가 바뀌는지 확인"){
+                result.isOpened shouldBe false
             }
         }
     }


### PR DESCRIPTION
## 💡 개요
* 동아리 신청 마감 API

## 📃 작업내용
* 신청 마감 API 개발
* 테스트 코드

## 🔀 변경사항
* 시큐리티에 신청 마감 uri 추가

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
