### PR TITLE
🔀 :: 56-유저탈퇴 API

### DIFF
--- a/src/main/kotlin/com/msg/gcms/domain/applicant/domain/entity/Applicant.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/applicant/domain/entity/Applicant.kt
@@ -3,6 +3,8 @@ package com.msg.gcms.domain.applicant.domain.entity
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.msg.gcms.domain.club.domain.entity.Club
 import com.msg.gcms.domain.user.domain.entity.User
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
 import javax.persistence.*
 
 @Entity
@@ -18,6 +20,7 @@ class Applicant(
 
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "user_id")
     val user: User
 ) {

--- a/src/main/kotlin/com/msg/gcms/domain/club/domain/repository/ClubRepository.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/domain/repository/ClubRepository.kt
@@ -9,4 +9,5 @@ interface ClubRepository : CrudRepository<Club, Long> {
     fun findByType(type: ClubType): List<Club>
     fun findByUser(user: User): List<Club>
     fun existsByUserAndType(user: User, type: ClubType): Boolean
+    fun existsByUser(user: User): Boolean
 }

--- a/src/main/kotlin/com/msg/gcms/domain/clubMember/domain/entity/ClubMember.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/clubMember/domain/entity/ClubMember.kt
@@ -3,6 +3,8 @@ package com.msg.gcms.domain.clubMember.domain.entity
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.msg.gcms.domain.club.domain.entity.Club
 import com.msg.gcms.domain.user.domain.entity.User
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
 import javax.persistence.*
 
 @Entity
@@ -18,6 +20,7 @@ class ClubMember(
 
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "user_id")
     val user: User
 ) {

--- a/src/main/kotlin/com/msg/gcms/domain/user/exception/UserIsHeadException.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/user/exception/UserIsHeadException.kt
@@ -1,0 +1,6 @@
+package com.msg.gcms.domain.user.exception
+
+import com.msg.gcms.global.exception.ErrorCode
+import com.msg.gcms.global.exception.exceptions.BasicException
+
+class UserIsHeadException : BasicException(ErrorCode.USER_IS_HEAD)

--- a/src/main/kotlin/com/msg/gcms/domain/user/presentaion/UserController.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/user/presentaion/UserController.kt
@@ -7,8 +7,10 @@ import com.msg.gcms.domain.user.presentaion.data.response.UserResponseDto
 import com.msg.gcms.domain.user.service.FindUserService
 import com.msg.gcms.domain.user.service.SearchUserService
 import com.msg.gcms.domain.user.service.UpdateProfileImgService
+import com.msg.gcms.domain.user.service.WithdrawUserService
 import com.msg.gcms.domain.user.utils.UserConverter
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -22,7 +24,8 @@ class UserController(
     private val userConverter: UserConverter,
     private val findUserService: FindUserService,
     private val searchUserService: SearchUserService,
-    private val updateProfileImgService: UpdateProfileImgService
+    private val updateProfileImgService: UpdateProfileImgService,
+    private val withdrawUserService: WithdrawUserService
 ) {
     @GetMapping
     fun findUser(): ResponseEntity<UserResponseDto> {
@@ -43,6 +46,10 @@ class UserController(
     fun updateProfileImg(@RequestBody requestDto: UpdateProfileImgRequestDto): ResponseEntity<Void> =
         userConverter.toDto(requestDto)
             .let { updateProfileImgService.execute(it) }
+            .let { ResponseEntity.noContent().build() }
+    @DeleteMapping
+    fun withdrawUser(): ResponseEntity<Void> =
+        withdrawUserService.execute()
             .let { ResponseEntity.noContent().build() }
 
 }

--- a/src/main/kotlin/com/msg/gcms/domain/user/service/WithdrawUserService.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/user/service/WithdrawUserService.kt
@@ -1,0 +1,5 @@
+package com.msg.gcms.domain.user.service
+
+interface WithdrawUserService {
+    fun execute()
+}

--- a/src/main/kotlin/com/msg/gcms/domain/user/service/impl/UpdateProfileImgServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/user/service/impl/UpdateProfileImgServiceImpl.kt
@@ -12,7 +12,7 @@ class UpdateProfileImgServiceImpl(
     private val userUtil: UserUtil,
     private val userRepository: UserRepository
 ) : UpdateProfileImgService {
-    @Transactional(readOnly = true, rollbackFor = [Exception::class])
+    @Transactional(rollbackFor = [Exception::class])
     override fun execute(dto: ProfileImgDto) {
         val user = userUtil.fetchCurrentUser()
         user.updateProfileImg(dto.profileImg)

--- a/src/main/kotlin/com/msg/gcms/domain/user/service/impl/WithdrawUserServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/user/service/impl/WithdrawUserServiceImpl.kt
@@ -1,0 +1,9 @@
+package com.msg.gcms.domain.user.service.impl
+
+import com.msg.gcms.domain.user.service.WithdrawUserService
+
+class WithdrawUserServiceImpl : WithdrawUserService {
+    override fun execute() {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/main/kotlin/com/msg/gcms/domain/user/service/impl/WithdrawUserServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/user/service/impl/WithdrawUserServiceImpl.kt
@@ -1,7 +1,9 @@
 package com.msg.gcms.domain.user.service.impl
 
 import com.msg.gcms.domain.user.service.WithdrawUserService
+import org.springframework.stereotype.Service
 
+@Service
 class WithdrawUserServiceImpl : WithdrawUserService {
     override fun execute() {
         TODO("Not yet implemented")

--- a/src/main/kotlin/com/msg/gcms/domain/user/service/impl/WithdrawUserServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/user/service/impl/WithdrawUserServiceImpl.kt
@@ -1,11 +1,25 @@
 package com.msg.gcms.domain.user.service.impl
 
+import com.msg.gcms.domain.club.domain.repository.ClubRepository
+import com.msg.gcms.domain.user.domain.repository.UserRepository
+import com.msg.gcms.domain.user.exception.UserIsHeadException
 import com.msg.gcms.domain.user.service.WithdrawUserService
+import com.msg.gcms.global.util.UserUtil
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
-class WithdrawUserServiceImpl : WithdrawUserService {
+class WithdrawUserServiceImpl(
+    private val userUtil: UserUtil,
+    private val userRepository: UserRepository,
+    private val clubRepository: ClubRepository
+) : WithdrawUserService {
+    @Transactional(rollbackFor = [Exception::class])
     override fun execute() {
-        TODO("Not yet implemented")
+        val user = userUtil.fetchCurrentUser()
+        if(clubRepository.existsByUser(user)) {
+            throw UserIsHeadException()
+        }
+        userRepository.delete(user)
     }
 }

--- a/src/main/kotlin/com/msg/gcms/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/msg/gcms/global/exception/ErrorCode.kt
@@ -4,6 +4,8 @@ enum class ErrorCode(
     val message: String,
     val status: Int
 ) {
+    USER_IS_HEAD("동아리의 부장임", 400),
+
     UNAUTHORIZED("권한이 없음", 401),
     EXPIRED_TOKEN("만료된 토큰", 401),
 

--- a/src/main/kotlin/com/msg/gcms/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/msg/gcms/global/security/SecurityConfig.kt
@@ -49,6 +49,7 @@ class SecurityConfig(
             .antMatchers(HttpMethod.GET,"/user").authenticated()
             .antMatchers(HttpMethod.GET,"/user/search").authenticated()
             .antMatchers(HttpMethod.PATCH, "/user").authenticated()
+            .antMatchers(HttpMethod.DELETE, "/user").permitAll()
 
             .anyRequest().denyAll()
             .and()

--- a/src/main/kotlin/com/msg/gcms/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/msg/gcms/global/security/SecurityConfig.kt
@@ -49,7 +49,7 @@ class SecurityConfig(
             .antMatchers(HttpMethod.GET,"/user").authenticated()
             .antMatchers(HttpMethod.GET,"/user/search").authenticated()
             .antMatchers(HttpMethod.PATCH, "/user").authenticated()
-            .antMatchers(HttpMethod.DELETE, "/user").permitAll()
+            .antMatchers(HttpMethod.DELETE, "/user").authenticated()
 
             .anyRequest().denyAll()
             .and()

--- a/src/test/kotlin/com/msg/gcms/domain/user/controller/FindUserControllerTest.kt
+++ b/src/test/kotlin/com/msg/gcms/domain/user/controller/FindUserControllerTest.kt
@@ -4,6 +4,7 @@ import com.msg.gcms.domain.user.presentaion.UserController
 import com.msg.gcms.domain.user.service.FindUserService
 import com.msg.gcms.domain.user.service.SearchUserService
 import com.msg.gcms.domain.user.service.UpdateProfileImgService
+import com.msg.gcms.domain.user.service.WithdrawUserService
 import com.msg.gcms.domain.user.utils.UserConverter
 import com.msg.gcms.domain.user.utils.impl.UserConverterImpl
 import com.msg.gcms.testUtils.TestUtils
@@ -24,7 +25,8 @@ class FindUserControllerTest : BehaviorSpec({
     val searchUserService = mockk<SearchUserService>()
     val findUserService = mockk<FindUserService>()
     val updateProfileImgService = mockk<UpdateProfileImgService>()
-    val clubController = UserController(userConverter(), findUserService, searchUserService, updateProfileImgService)
+    val withdrawUserService = mockk<WithdrawUserService>()
+    val clubController = UserController(userConverter(), findUserService, searchUserService, updateProfileImgService, withdrawUserService)
 
     given("find user request") {
         val userDto = TestUtils.data().user().userDto()

--- a/src/test/kotlin/com/msg/gcms/domain/user/controller/SearchUserControllerTest.kt
+++ b/src/test/kotlin/com/msg/gcms/domain/user/controller/SearchUserControllerTest.kt
@@ -6,6 +6,7 @@ import com.msg.gcms.domain.user.presentaion.data.dto.SearchRequirementDto
 import com.msg.gcms.domain.user.service.FindUserService
 import com.msg.gcms.domain.user.service.SearchUserService
 import com.msg.gcms.domain.user.service.UpdateProfileImgService
+import com.msg.gcms.domain.user.service.WithdrawUserService
 import com.msg.gcms.domain.user.utils.UserConverter
 import com.msg.gcms.domain.user.utils.impl.UserConverterImpl
 import com.msg.gcms.testUtils.TestUtils
@@ -26,7 +27,8 @@ class SearchUserControllerTest : BehaviorSpec({
     val searchUserService = mockk<SearchUserService>()
     val findUserService = mockk<FindUserService>()
     val updateProfileImgService = mockk<UpdateProfileImgService>()
-    val clubController = UserController(userConverter(), findUserService, searchUserService, updateProfileImgService)
+    val withdrawUserService = mockk<WithdrawUserService>()
+    val clubController = UserController(userConverter(), findUserService, searchUserService, updateProfileImgService, withdrawUserService)
 
     given("search user request") {
         val type = ClubType.values().random()

--- a/src/test/kotlin/com/msg/gcms/domain/user/controller/UpdateProfileImgControllerTest.kt
+++ b/src/test/kotlin/com/msg/gcms/domain/user/controller/UpdateProfileImgControllerTest.kt
@@ -8,6 +8,7 @@ import com.msg.gcms.domain.user.presentaion.data.request.UpdateProfileImgRequest
 import com.msg.gcms.domain.user.service.FindUserService
 import com.msg.gcms.domain.user.service.SearchUserService
 import com.msg.gcms.domain.user.service.UpdateProfileImgService
+import com.msg.gcms.domain.user.service.WithdrawUserService
 import com.msg.gcms.domain.user.utils.UserConverter
 import com.msg.gcms.domain.user.utils.impl.UserConverterImpl
 import com.msg.gcms.testUtils.TestUtils
@@ -28,7 +29,8 @@ class UpdateProfileImgControllerTest : BehaviorSpec({
     val searchUserService = mockk<SearchUserService>()
     val findUserService = mockk<FindUserService>()
     val updateProfileImgService = mockk<UpdateProfileImgService>()
-    val clubController = UserController(userConverter(), findUserService, searchUserService, updateProfileImgService)
+    val withdrawUserService = mockk<WithdrawUserService>()
+    val clubController = UserController(userConverter(), findUserService, searchUserService, updateProfileImgService, withdrawUserService)
 
     given("update profileImg request") {
         val profileImg = TestUtils.data().user().profileImg()

--- a/src/test/kotlin/com/msg/gcms/domain/user/controller/WithdrawUserControllerTest.kt
+++ b/src/test/kotlin/com/msg/gcms/domain/user/controller/WithdrawUserControllerTest.kt
@@ -1,0 +1,38 @@
+package com.msg.gcms.domain.user.controller
+
+import com.msg.gcms.domain.user.presentaion.UserController
+import com.msg.gcms.domain.user.service.FindUserService
+import com.msg.gcms.domain.user.service.SearchUserService
+import com.msg.gcms.domain.user.service.UpdateProfileImgService
+import com.msg.gcms.domain.user.service.WithdrawUserService
+import com.msg.gcms.domain.user.utils.UserConverter
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.http.HttpStatus
+
+class WithdrawUserControllerTest : BehaviorSpec({
+    val userConverter = mockk<UserConverter>()
+    val searchUserService = mockk<SearchUserService>()
+    val findUserService = mockk<FindUserService>()
+    val updateProfileImgService = mockk<UpdateProfileImgService>()
+    val withdrawUserService = mockk<WithdrawUserService>()
+    val clubController = UserController(userConverter, findUserService, searchUserService, updateProfileImgService, withdrawUserService)
+
+    given("withdraw user request") {
+
+        `when`("is received") {
+            every { withdrawUserService.execute() } returns Unit
+            val response = clubController.withdrawUser()
+
+            then("business logic in withdrawUserService should be called") {
+                verify(exactly = 1) { withdrawUserService.execute() }
+            }
+            then("response status should be no_content") {
+                response.statusCode shouldBe HttpStatus.NO_CONTENT
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/msg/gcms/domain/user/service/WithdrawUserServiceTest.kt
+++ b/src/test/kotlin/com/msg/gcms/domain/user/service/WithdrawUserServiceTest.kt
@@ -1,0 +1,42 @@
+package com.msg.gcms.domain.user.service
+
+import com.msg.gcms.domain.club.domain.repository.ClubRepository
+import com.msg.gcms.domain.user.domain.repository.UserRepository
+import com.msg.gcms.domain.user.service.impl.WithdrawUserServiceImpl
+import com.msg.gcms.global.util.UserUtil
+import com.msg.gcms.testUtils.TestUtils
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class WithdrawUserServiceTest : BehaviorSpec({
+    val userUtil = mockk<UserUtil>()
+    val userRepository = mockk<UserRepository>()
+    val clubRepository = mockk<ClubRepository>()
+    val withdrawUserServiceImpl = WithdrawUserServiceImpl(userUtil, userRepository, clubRepository)
+
+    extension(SpringExtension)
+    given("withdraw user") {
+        val user = TestUtils.data().user().entity()
+
+        `when`("is invoked") {
+            every { userUtil.fetchCurrentUser() } returns user
+            every { clubRepository.existsByUser(user) } returns false
+            every { userRepository.delete(user) } returns Unit
+            withdrawUserServiceImpl.execute()
+
+            then("fetchCurrentUser in userUtil should be called") {
+                verify(exactly = 1) { userUtil.fetchCurrentUser() }
+            }
+            then("existsByUser in clubRepository should be called") {
+                verify(exactly = 1) { clubRepository.existsByUser(user) }
+            }
+            then("deleteUser in userRepository should be called") {
+                verify(exactly = 1) { userRepository.delete(user) }
+            }
+        }
+    }
+}) {
+}


### PR DESCRIPTION
## 💡 개요
* 유저탈퇴 API 구현
## 📃 작업내용
* 유저탈퇴 API 구현
* cascade 옵션 추가
* 유저 탈퇴 테스트코드 작성
## 🔀 변경사항
* 신청자와 멤버 엔티티에 casCade 옵션 추가
## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
