### PR TITLE
🔀 :: 101 동아리 디테일 페이지 permitAll로 수정

### DIFF
--- a/src/main/kotlin/com/msg/gcms/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/msg/gcms/global/security/SecurityConfig.kt
@@ -45,7 +45,7 @@ class SecurityConfig(
 
             .antMatchers(HttpMethod.POST, "/club").authenticated()
             .antMatchers(HttpMethod.GET, "/club").permitAll()
-            .antMatchers(HttpMethod.GET, "/club/{club_id}").authenticated()
+            .antMatchers(HttpMethod.GET, "/club/{club_id}").permitAll()
             .antMatchers(HttpMethod.PATCH, "/club/{club_id}").authenticated()
             .antMatchers(HttpMethod.PATCH, "/club/{club_id}/close").authenticated()
             .antMatchers(HttpMethod.PATCH, "/club/{club_id}/open").permitAll()

--- a/src/main/kotlin/com/msg/gcms/global/util/UserUtil.kt
+++ b/src/main/kotlin/com/msg/gcms/global/util/UserUtil.kt
@@ -12,15 +12,19 @@ class UserUtil(
     private val userRepository: UserRepository
 ) {
     fun fetchCurrentUser(): User {
+        val email = fetchUserEmail()
+        return fetchUserByEmail(email)
+    }
+
+    fun fetchUserByEmail(email: String): User =
+        userRepository.findByEmail(email) ?: throw UserNotFoundException()
+    fun fetchUserEmail(): String {
         val principal = SecurityContextHolder.getContext().authentication.principal
         val email = if (principal is AuthDetails) {
             principal.username
         } else {
             principal.toString()
         }
-        return fetchUserByEmail(email)
+        return email
     }
-
-    fun fetchUserByEmail(email: String): User =
-        userRepository.findByEmail(email) ?: throw UserNotFoundException()
 }


### PR DESCRIPTION
## 💡 개요
* 프론트의 요청으로 토큰없이 디테일 페이지를 열람할 수 있게 수정했습니다.
## 📃 작업내용
* 디테일 페이지를 토큰없이 열람할 수 있도록 작업했습니다.
## 🔀 변경사항
* userUtils에 email을 가져오는 부분을 함수로 변환
* email에 유무에 따라서 로직이 실행되게 변경
## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
