### PR TITLE
🔀 :: 105 - 유저 검색에 본인이 나오지않도록 수정

### DIFF
--- a/src/main/kotlin/com/msg/gcms/domain/user/service/impl/SearchUserServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/user/service/impl/SearchUserServiceImpl.kt
@@ -22,18 +22,18 @@ class SearchUserServiceImpl(
     @Transactional(readOnly = true, rollbackFor = [Exception::class])
     override fun execute(dto: SearchRequirementDto): List<SearchUserDto> {
         val user = userUtil.fetchCurrentUser()
-        if (dto.clubType != ClubType.MAJOR
+        return if (dto.clubType != ClubType.MAJOR
             && dto.clubType != ClubType.FREEDOM
         ) {
-            return  userRepository.findByNicknameContaining(dto.name)
+            userRepository.findByNicknameContaining(dto.name)
                 .filter { it.id != user.id }
                 .map { userConverter.toDto(it) }
         } else {
-            return userRepository.findUserNotJoin(dto.clubType, dto.name)
+            userRepository.findUserNotJoin(dto.clubType, dto.name)
                 .filter { !verifyUserIsHead(it, dto.clubType) }
                 .filter { it.id != user.id }
                 .map { userConverter.toDto(it) }
-        }
+        } 
     }
     private fun verifyUserIsHead(user: User, type: ClubType): Boolean =
         clubRepository.existsByUserAndType(user, type)

--- a/src/main/kotlin/com/msg/gcms/domain/user/service/impl/SearchUserServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/user/service/impl/SearchUserServiceImpl.kt
@@ -8,26 +8,33 @@ import com.msg.gcms.domain.user.presentaion.data.dto.SearchRequirementDto
 import com.msg.gcms.domain.user.presentaion.data.dto.SearchUserDto
 import com.msg.gcms.domain.user.service.SearchUserService
 import com.msg.gcms.domain.user.utils.UserConverter
+import com.msg.gcms.global.util.UserUtil
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class SearchUserServiceImpl(
+    val userUtil: UserUtil,
     val userRepository: UserRepository,
     val clubRepository: ClubRepository,
     val userConverter: UserConverter,
 ) : SearchUserService {
     @Transactional(readOnly = true, rollbackFor = [Exception::class])
-    override fun execute(dto: SearchRequirementDto): List<SearchUserDto> =
+    override fun execute(dto: SearchRequirementDto): List<SearchUserDto> {
+        val user = userUtil.fetchCurrentUser()
         if (dto.clubType != ClubType.MAJOR
-            && dto.clubType != ClubType.FREEDOM) {
-            userRepository.findByNicknameContaining(dto.name)
+            && dto.clubType != ClubType.FREEDOM
+        ) {
+            return  userRepository.findByNicknameContaining(dto.name)
+                .filter { it.id != user.id }
                 .map { userConverter.toDto(it) }
         } else {
-            userRepository.findUserNotJoin(dto.clubType, dto.name)
+            return userRepository.findUserNotJoin(dto.clubType, dto.name)
                 .filter { !verifyUserIsHead(it, dto.clubType) }
+                .filter { it.id != user.id }
                 .map { userConverter.toDto(it) }
         }
+    }
     private fun verifyUserIsHead(user: User, type: ClubType): Boolean =
         clubRepository.existsByUserAndType(user, type)
 }

--- a/src/test/kotlin/com/msg/gcms/domain/user/service/SearchUserServiceTest.kt
+++ b/src/test/kotlin/com/msg/gcms/domain/user/service/SearchUserServiceTest.kt
@@ -7,6 +7,7 @@ import com.msg.gcms.domain.user.presentaion.data.dto.SearchRequirementDto
 import com.msg.gcms.domain.user.service.impl.SearchUserServiceImpl
 import com.msg.gcms.domain.user.utils.UserConverter
 import com.msg.gcms.domain.user.utils.impl.UserConverterImpl
+import com.msg.gcms.global.util.UserUtil
 import com.msg.gcms.testUtils.TestUtils
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -22,8 +23,9 @@ class SearchUserServiceTest : BehaviorSpec({
         return UserConverterImpl()
     }
     val userRepository = mockk<UserRepository>()
+    val userUtil = mockk<UserUtil>()
     val clubRepository = mockk<ClubRepository>()
-    val searchUserServiceImpl = SearchUserServiceImpl(userRepository, clubRepository, userConverter())
+    val searchUserServiceImpl = SearchUserServiceImpl(userUtil, userRepository, clubRepository, userConverter())
 
     given("search user With Type Is MAJOR OR FREEDOM") {
         val size = (1..100).random()


### PR DESCRIPTION
## 💡 개요
* 유저 검색시 자신을 검색하면 검색되는 
## 📃 작업내용
* 유저 검색시 자신이 안나오도록 필터링
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
