### PR TITLE
🔀 :: 109-자율/전공 동아리 부장혹은 구성원일때 동아리를 생성하지 못하도록 수정

### DIFF
--- a/src/main/kotlin/com/msg/gcms/domain/club/exception/AlreadyClubHeadException.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/exception/AlreadyClubHeadException.kt
@@ -1,0 +1,6 @@
+package com.msg.gcms.domain.club.exception
+
+import com.msg.gcms.global.exception.ErrorCode
+import com.msg.gcms.global.exception.exceptions.BasicException
+
+class AlreadyClubHeadException : BasicException(ErrorCode.ALREADY_CLUB_HEAD)

--- a/src/main/kotlin/com/msg/gcms/domain/club/service/impl/CreateClubServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/service/impl/CreateClubServiceImpl.kt
@@ -1,11 +1,18 @@
 package com.msg.gcms.domain.club.service.impl
 
+import com.msg.gcms.domain.applicant.exception.AlreadyClubMemberException
+import com.msg.gcms.domain.club.domain.entity.Club
 import com.msg.gcms.domain.club.domain.repository.ClubRepository
+import com.msg.gcms.domain.club.enums.ClubType
+import com.msg.gcms.domain.club.exception.AlreadyClubHeadException
 import com.msg.gcms.domain.club.exception.ClubAlreadyExistsException
 import com.msg.gcms.domain.club.presentation.data.dto.ClubDto
 import com.msg.gcms.domain.club.service.CreateClubService
 import com.msg.gcms.domain.club.utils.ClubConverter
 import com.msg.gcms.domain.club.utils.SaveClubUtil
+import com.msg.gcms.domain.clubMember.domain.entity.ClubMember
+import com.msg.gcms.domain.clubMember.domain.repository.ClubMemberRepository
+import com.msg.gcms.domain.user.domain.entity.User
 import com.msg.gcms.global.util.UserUtil
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -16,6 +23,7 @@ class CreateClubServiceImpl(
     private val userUtil: UserUtil,
     private val saveClubUtil: SaveClubUtil,
     private val clubRepository: ClubRepository,
+    private val clubMemberRepository: ClubMemberRepository,
     private val clubConverter: ClubConverter
 ) : CreateClubService {
     override fun execute(clubDto: ClubDto) {
@@ -23,6 +31,24 @@ class CreateClubServiceImpl(
             throw ClubAlreadyExistsException()
         val currentUser = userUtil.fetchCurrentUser()
         val club = clubConverter.toEntity(clubDto, currentUser)
+        checkAlreadyHead(currentUser, clubDto)
+        checkAlreadyClubMember(currentUser, clubDto)
         saveClubUtil.saveClub(club, clubDto.activityImgs, clubDto.member)
+    }
+
+    private fun checkAlreadyHead(
+        currentUser: User,
+        clubDto: ClubDto
+    ) {
+        if (clubDto.type != ClubType.EDITORIAL && clubRepository.existsByUserAndType(currentUser, clubDto.type))
+            throw AlreadyClubHeadException()
+    }
+
+    private fun checkAlreadyClubMember(
+        currentUser: User,
+        clubDto: ClubDto
+    ){
+        if (clubDto.type != ClubType.EDITORIAL && clubMemberRepository.findByUser(currentUser).any { it.club.type == clubDto.type })
+            throw AlreadyClubMemberException()
     }
 }

--- a/src/main/kotlin/com/msg/gcms/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/msg/gcms/global/exception/ErrorCode.kt
@@ -16,6 +16,7 @@ enum class ErrorCode(
     NOT_CLUB_EXIT("해당 동아리를 나갈 수 없음", 403),
     NOT_CLUB_MEMBER("해당 동아리의 구성원이 아님", 403),
     ALREADY_CLUB_MEMBER("이미 동아리 구성원임", 403),
+    ALREADY_CLUB_HEAD("이미 동아리 부장임", 403),
     DUPLICATE_APPLICANT("같은 타입의 동아리에 이미 신청함", 403),
     NOT_APPLICANT("해당 동아리에 가입 신청하지 않음", 403),
 


### PR DESCRIPTION
## 💡 개요
* 한 사람이 전공 동아리를 여러개 만들 수 있음

## 📃 작업내용
* 자율/전공 동아리 부장이나 구성원이먼 동아리를 생성 못 하도록 수정

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
