### PR TITLE
🔀 :: 119-동아리 구성원에 부장이 들어있는지 확인하는 로직 추가

### DIFF
--- a/src/main/kotlin/com/msg/gcms/domain/club/utils/SaveClubUtil.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/utils/SaveClubUtil.kt
@@ -26,6 +26,7 @@ class SaveClubUtil(
         activityImgRepository.saveAll(activityImgs)
         val users = users
             .map { findById(it) }
+            .filter{ it != club.user }
             .map { ClubMember(club = club, user = it) }
         clubMemberRepository.saveAll(users)
     }


### PR DESCRIPTION
## 💡 개요
* 프론트가 동아리 수정할때 부장을 동아리 멤버 리스트에 보내서 알게된 버그

## 📃 작업내용
* 동아리 저장하는 객체에 부장이 동아리 멤버 리스트로 들어가있는지 확인하는 로직 추가

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
