### PR TITLE
🔀 ::  118 - 이미지 개수 수정

### DIFF
--- a/src/main/kotlin/com/msg/gcms/domain/image/utils/impl/ImageValidatorImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/image/utils/impl/ImageValidatorImpl.kt
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component
 @Component
 class ImageValidatorImpl : ImageValidator {
     override fun validatorFileSize(size: Int) {
-       if(size > 4) {
+       if(size > 5) {
            throw FileSizeOverException()
        }
     }


### PR DESCRIPTION
## 💡 개요
* 프론트에서 배너이미지와 활동사진을 한번에 보내는 로직처리로 인해 수정이 필요함
## 📃 작업내용
* validator조건식에 수를 수정
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
