### PR TITLE
🔀 :: 130 - 동아리 수락 API 구현

### DIFF
--- a/src/main/kotlin/com/msg/gcms/domain/admin/presentation/AdminController.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/admin/presentation/AdminController.kt
@@ -1,34 +1,24 @@
 package com.msg.gcms.domain.admin.presentation
 
-<<<<<<< HEAD
 import com.msg.gcms.domain.admin.service.AcceptClubService
-import com.msg.gcms.global.annotation.RequestController
-import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.PatchMapping
-import org.springframework.web.bind.annotation.PathVariable
-
-@RequestController("/admin")
-class AdminController(
-    private val acceptClubService: AcceptClubService
-) {
-    @PatchMapping("/{club_id}")
-    fun acceptClub(@PathVariable("club_id") clubId: Long) : ResponseEntity<Void> =
-        acceptClubService.execute(clubId = clubId)
-            .let { ResponseEntity.noContent().build() }
-=======
 import com.msg.gcms.domain.admin.service.CreateClubMemberExcelByClassNumService
 import com.msg.gcms.domain.admin.service.CreateClubMemberExcelService
 import com.msg.gcms.domain.club.enums.ClubType
 import com.msg.gcms.global.annotation.RequestController
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
 import javax.servlet.http.HttpServletResponse
 
 @RequestController("/admin")
 class AdminController(
+    private val acceptClubService: AcceptClubService,
     private val createClubMemberExcelService: CreateClubMemberExcelService,
     private val createClubMemberExcelByClassNumService: CreateClubMemberExcelByClassNumService
 ) {
+
     @GetMapping("/excel/club")
     fun getClubMemberExcelByClub(@RequestParam clubType: ClubType, response: HttpServletResponse): ByteArray{
         response.setHeader("Content-Disposition", "attachment; filename=club.xlsx")
@@ -40,5 +30,8 @@ class AdminController(
         response.setHeader("Content-Disposition", "attachment; filename=club_assign_status.xlsx")
         return createClubMemberExcelByClassNumService.execute(clubType)
     }
->>>>>>> 7ec78a2ea5eca09d70f268db6db4d195e4ab0f39
+    @PatchMapping("/{club_id}")
+    fun acceptClub(@PathVariable("club_id") clubId: Long) : ResponseEntity<Void> =
+        acceptClubService.execute(clubId = clubId)
+            .let { ResponseEntity.noContent().build() }
 }

--- a/src/main/kotlin/com/msg/gcms/domain/admin/presentation/AdminController.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/admin/presentation/AdminController.kt
@@ -1,0 +1,17 @@
+package com.msg.gcms.domain.admin.presentation
+
+import com.msg.gcms.domain.admin.service.AcceptClubService
+import com.msg.gcms.global.annotation.RequestController
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+
+@RequestController("/admin")
+class AdminController(
+    private val acceptClubService: AcceptClubService
+) {
+    @PatchMapping("/{club_id}")
+    fun acceptClub(@PathVariable("club_id") clubId: Long) : ResponseEntity<Void> =
+        acceptClubService.execute(clubId = clubId)
+            .let { ResponseEntity.noContent().build() }
+}

--- a/src/main/kotlin/com/msg/gcms/domain/admin/service/AcceptClubService.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/admin/service/AcceptClubService.kt
@@ -1,0 +1,5 @@
+package com.msg.gcms.domain.admin.service
+
+interface AcceptClubService {
+    fun execute(clubId: Long)
+}

--- a/src/main/kotlin/com/msg/gcms/domain/admin/service/impl/AcceptClubServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/admin/service/impl/AcceptClubServiceImpl.kt
@@ -1,0 +1,11 @@
+package com.msg.gcms.domain.admin.service.impl
+
+import com.msg.gcms.domain.admin.service.AcceptClubService
+import org.springframework.stereotype.Service
+
+@Service
+class AcceptClubServiceImpl : AcceptClubService {
+    override fun execute(clubId: Long) {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/main/kotlin/com/msg/gcms/domain/admin/service/impl/AcceptClubServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/admin/service/impl/AcceptClubServiceImpl.kt
@@ -1,11 +1,40 @@
 package com.msg.gcms.domain.admin.service.impl
 
 import com.msg.gcms.domain.admin.service.AcceptClubService
+import com.msg.gcms.domain.club.domain.entity.Club
+import com.msg.gcms.domain.club.domain.repository.ClubRepository
+import com.msg.gcms.domain.club.enums.ClubStatus
+import com.msg.gcms.domain.club.exception.ClubNotFoundException
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.lang.Exception
 
 @Service
-class AcceptClubServiceImpl : AcceptClubService {
+@Transactional(rollbackFor = [Exception::class])
+class AcceptClubServiceImpl(
+    private val clubRepository: ClubRepository
+) : AcceptClubService {
     override fun execute(clubId: Long) {
-        TODO("Not yet implemented")
+        val club = clubRepository.findByIdOrNull(clubId) ?: throw ClubNotFoundException()
+
+        val newClub = Club(
+            id = club.id,
+            activityImg = club.activityImg,
+            applicant = club.applicant,
+            bannerImg = club.bannerImg,
+            clubMember = club.clubMember,
+            contact = club.contact,
+            content = club.content,
+            name = club.name,
+            notionLink = club.notionLink,
+            teacher = club.teacher,
+            type = club.type,
+            user = club.user,
+            isOpened = true,
+            clubStatus = ClubStatus.CREATED
+        )
+
+        clubRepository.save(newClub)
     }
 }

--- a/src/main/kotlin/com/msg/gcms/domain/club/utils/impl/ClubConverterImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/utils/impl/ClubConverterImpl.kt
@@ -1,6 +1,7 @@
 package com.msg.gcms.domain.club.utils.impl
 
 import com.msg.gcms.domain.club.domain.entity.Club
+import com.msg.gcms.domain.club.enums.ClubStatus
 import com.msg.gcms.domain.club.enums.ClubType
 import com.msg.gcms.domain.club.enums.Scope
 import com.msg.gcms.domain.club.presentation.data.dto.*

--- a/src/main/kotlin/com/msg/gcms/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/msg/gcms/global/security/SecurityConfig.kt
@@ -68,8 +68,8 @@ class SecurityConfig(
             .antMatchers(HttpMethod.POST, "/image").authenticated()
 
             .antMatchers(HttpMethod.GET, "/admin/excel/club").permitAll()
-            .antMatchers(HttpMethod.GET, "/admin/excel/club/grade").hasRole("ROLE_ADMIN")
-            .antMatchers(HttpMethod.POST, "/admin").hasRole("ROLE_ADMIN")
+            .antMatchers(HttpMethod.GET, "/admin/excel/club/grade").hasRole("ADMIN")
+            .antMatchers(HttpMethod.POST, "/admin").hasRole("ADMIN")
             .anyRequest().denyAll()
             .and()
             .exceptionHandling()

--- a/src/main/kotlin/com/msg/gcms/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/msg/gcms/global/security/SecurityConfig.kt
@@ -68,7 +68,8 @@ class SecurityConfig(
             .antMatchers(HttpMethod.POST, "/image").authenticated()
 
             .antMatchers(HttpMethod.GET, "/admin/excel/club").permitAll()
-            .antMatchers(HttpMethod.GET, "/admin/excel/club/grade").hasRole("ADMIN")
+            .antMatchers(HttpMethod.GET, "/admin/excel/club/grade").hasRole("ROLE_ADMIN")
+            .antMatchers(HttpMethod.POST, "/admin").hasRole("ROLE_ADMIN")
             .anyRequest().denyAll()
             .and()
             .exceptionHandling()


### PR DESCRIPTION
## 💡 개요
* 어드민이 동아리 생성을 위해 동아리 생성을 허가하는 API
## 📃 작업내용
* 로직 구현
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
