### PR TITLE
🔀 :: 157 - 유저페이지 동아리 정보 로직 수정

### DIFF
--- a/src/main/kotlin/com/msg/gcms/domain/club/domain/repository/ClubRepository.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/domain/repository/ClubRepository.kt
@@ -8,6 +8,7 @@ import org.springframework.data.repository.CrudRepository
 
 interface ClubRepository : CrudRepository<Club, Long> {
     fun findByTypeAndClubStatus(type: ClubType, status: ClubStatus): List<Club>
+    fun findAllByClubStatusAndUser(user: User, status: ClubStatus): List<Club>
     fun findByType(type: ClubType): List<Club>
     fun findAllByClubStatus(status: ClubStatus): List<Club>
     fun findByUser(user: User): List<Club>

--- a/src/main/kotlin/com/msg/gcms/domain/user/service/impl/FindUserServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/user/service/impl/FindUserServiceImpl.kt
@@ -2,6 +2,7 @@ package com.msg.gcms.domain.user.service.impl
 
 import com.msg.gcms.domain.club.domain.entity.Club
 import com.msg.gcms.domain.club.domain.repository.ClubRepository
+import com.msg.gcms.domain.club.enums.ClubStatus
 import com.msg.gcms.domain.clubMember.domain.repository.ClubMemberRepository
 import com.msg.gcms.domain.user.domain.entity.User
 import com.msg.gcms.domain.user.presentaion.data.dto.UserDto
@@ -21,14 +22,15 @@ class FindUserServiceImpl(
     @Transactional(readOnly = true, rollbackFor = [Exception::class])
     override fun execute(): UserDto {
         val user = userUtil.fetchCurrentUser()
-        val clubListDto = getClubListWithUser(user)
+        val clubListDto = getClubListByUser(user)
             .map { userConverter.toDto(it) }
         return userConverter.toDto(user,clubListDto)
     }
-    private fun getClubListWithUser(user: User): List<Club> {
-        val clubList = clubRepository.findByUser(user)
+    private fun getClubListByUser(user: User): List<Club> {
+        val clubList = clubRepository.findAllByClubStatusAndUser(user, ClubStatus.CREATED)
         val memberClubList = clubMemberRepository.findByUser(user)
             .map { it.club }
+            .filter { it.clubStatus == ClubStatus.CREATED }
         return clubList + memberClubList
     }
 


### PR DESCRIPTION
## 💡 개요
* 유저 정보에 생성되지 않는 동아리 정보가 뜨는 상황
## 📃 작업내용
* find조건 수정
* filter로 거르기
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
