### PR TITLE
🔀 :: 161 - 다중로그인 되게 변경

### DIFF
--- a/src/main/kotlin/com/msg/gcms/domain/auth/domain/entity/RefreshToken.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/auth/domain/entity/RefreshToken.kt
@@ -7,9 +7,9 @@ import java.util.UUID
 
 @RedisHash(value = "refreshToken", timeToLive = 60L * 60 * 24 * 7)
 class RefreshToken(
-    @Id
     @Indexed
     val userId: UUID? = null,
+    @Id
     @Indexed
     val token: String,
 )


### PR DESCRIPTION
## 💡 개요
* 다중로그인이 가능하게 변경

## 📃 작업내용
* RefreshTokenEntity의 Id를 token으로 변경

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
