### PR TITLE
🔀 :: 170 - 동아리 마감 여부 수정

### DIFF
--- a/src/main/kotlin/com/msg/gcms/domain/club/utils/impl/UpdateClubStatusUtil.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/utils/impl/UpdateClubStatusUtil.kt
@@ -22,7 +22,8 @@ class UpdateClubStatusUtil(
             teacher = club.teacher,
             type = club.type,
             user = club.user,
-            isOpened = isOpened
+            isOpened = isOpened,
+            clubStatus = club.clubStatus
         )
         clubRepository.save(newClub)
         return club


### PR DESCRIPTION
## 💡 개요
* 동아리 마감, 재오픈시 동아리가 생성 대기 중으로 돌아감
## 📃 작업내용
* status값 추가
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
