### PR TITLE
🔀 :: 178 - fcm 푸시알람 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 /src/main/resources/application-dev.yml
 docker-compose.yml
+/src/main/resources/msg-gcms-firebase-adminsdk-4bh18-0e0624833f.json

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,8 @@ dependencies {
 	kapt("com.querydsl:querydsl-apt:5.0.0:jpa")
 	implementation("org.apache.poi:poi:5.2.2")
 	implementation("org.apache.poi:poi-ooxml:5.2.2")
+	implementation("com.google.firebase:firebase-admin:7.3.0")
+	implementation("com.squareup.okhttp3:okhttp:4.2.2")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/com/msg/gcms/domain/admin/service/impl/AcceptClubServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/admin/service/impl/AcceptClubServiceImpl.kt
@@ -5,6 +5,8 @@ import com.msg.gcms.domain.club.domain.entity.Club
 import com.msg.gcms.domain.club.domain.repository.ClubRepository
 import com.msg.gcms.domain.club.enums.ClubStatus
 import com.msg.gcms.domain.club.exception.ClubNotFoundException
+import com.msg.gcms.global.fcm.enums.SendType
+import com.msg.gcms.global.util.MessageSendUtil
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -13,7 +15,8 @@ import java.lang.Exception
 @Service
 @Transactional(rollbackFor = [Exception::class])
 class AcceptClubServiceImpl(
-    private val clubRepository: ClubRepository
+    private val clubRepository: ClubRepository,
+    private val messageSendUtil: MessageSendUtil
 ) : AcceptClubService {
     override fun execute(clubId: Long) {
         val club = clubRepository.findByIdOrNull(clubId) ?: throw ClubNotFoundException()
@@ -36,5 +39,6 @@ class AcceptClubServiceImpl(
         )
 
         clubRepository.save(newClub)
+        messageSendUtil.send(club.user, "동아리 개설 승인", "동아리 개설 신청이 승인되었어요.", SendType.CLUB)
     }
 }

--- a/src/main/kotlin/com/msg/gcms/domain/admin/service/impl/RejectClubServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/admin/service/impl/RejectClubServiceImpl.kt
@@ -5,6 +5,8 @@ import com.msg.gcms.domain.admin.service.RejectClubService
 import com.msg.gcms.domain.club.domain.repository.ClubRepository
 import com.msg.gcms.domain.club.enums.ClubStatus
 import com.msg.gcms.domain.club.exception.ClubNotFoundException
+import com.msg.gcms.global.fcm.enums.SendType
+import com.msg.gcms.global.util.MessageSendUtil
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -12,7 +14,8 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional(rollbackFor = [Exception::class])
 class RejectClubServiceImpl(
-    private val clubRepository: ClubRepository
+    private val clubRepository: ClubRepository,
+    private val messageSendUtil: MessageSendUtil
 ) : RejectClubService {
     override fun execute(clubId: Long) {
         val club = clubRepository.findByIdOrNull(clubId) ?: throw ClubNotFoundException()
@@ -22,5 +25,6 @@ class RejectClubServiceImpl(
         }
 
         clubRepository.delete(club)
+        messageSendUtil.send(club.user, "동아리 개설 거절", "동아리 개설 신청이 거절되었어요.", SendType.CLUB)
     }
 }

--- a/src/main/kotlin/com/msg/gcms/domain/applicant/service/impl/AcceptApplicantServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/applicant/service/impl/AcceptApplicantServiceImpl.kt
@@ -12,6 +12,8 @@ import com.msg.gcms.domain.clubMember.domain.repository.ClubMemberRepository
 import com.msg.gcms.domain.user.domain.entity.User
 import com.msg.gcms.domain.user.domain.repository.UserRepository
 import com.msg.gcms.domain.user.exception.UserNotFoundException
+import com.msg.gcms.global.fcm.enums.SendType
+import com.msg.gcms.global.util.MessageSendUtil
 import com.msg.gcms.global.util.UserUtil
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -26,7 +28,8 @@ class AcceptApplicantServiceImpl(
     private val clubMemberRepository: ClubMemberRepository,
     private val userRepository: UserRepository,
     private val applicantConverter: ApplicantConverter,
-    private val userUtil: UserUtil
+    private val userUtil: UserUtil,
+    private val messageSendUtil: MessageSendUtil
 ) : AcceptApplicantService {
 
     override fun execute(clubId: Long, acceptDto: AcceptDto) {
@@ -50,5 +53,6 @@ class AcceptApplicantServiceImpl(
         val clubMember = applicantConverter.toEntity(clubInfo, applicantUser)
         clubMemberRepository.save(clubMember)
 
+        messageSendUtil.send(applicantUser, "동아리 신청 수락", "${clubInfo.name}에 수락되셨습니다.", SendType.CLUB)
     }
 }

--- a/src/main/kotlin/com/msg/gcms/domain/applicant/service/impl/ClubApplyServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/applicant/service/impl/ClubApplyServiceImpl.kt
@@ -10,6 +10,8 @@ import com.msg.gcms.domain.club.domain.repository.ClubRepository
 import com.msg.gcms.domain.club.enums.ClubType
 import com.msg.gcms.domain.club.exception.ClubNotFoundException
 import com.msg.gcms.domain.clubMember.domain.repository.ClubMemberRepository
+import com.msg.gcms.global.fcm.enums.SendType
+import com.msg.gcms.global.util.MessageSendUtil
 import com.msg.gcms.global.util.UserUtil
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -21,12 +23,14 @@ class ClubApplyServiceImpl(
     private val clubRepository: ClubRepository,
     private val clubMemberRepository: ClubMemberRepository,
     private val applicantSaveUtil: ApplicantSaveUtil,
-    private val applicantRepository: ApplicantRepository
+    private val applicantRepository: ApplicantRepository,
+    private val messageSendUtil: MessageSendUtil
 ) : ClubApplyService {
     override fun execute(clubId: Long): ClubApplyDto {
         val club = clubRepository.findById(clubId)
             .orElseThrow { ClubNotFoundException() }
         val user = userUtil.fetchCurrentUser()
+        messageSendUtil.send(club.user, "동아리 신청 요청", "${user.nickname}님이 ${club.name}에 신청했습니다.", SendType.CLUB)
         if (club.clubMember.contains(clubMemberRepository.findByUserAndClub(user, club)) || club.user == user && club.type != ClubType.EDITORIAL)
             throw AlreadyClubMemberException()
         if (applicantRepository.countByClubTypeAndUser(club.type, user) != 0L && club.type != ClubType.EDITORIAL)

--- a/src/main/kotlin/com/msg/gcms/domain/applicant/service/impl/RejectApplicantServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/applicant/service/impl/RejectApplicantServiceImpl.kt
@@ -11,6 +11,8 @@ import com.msg.gcms.domain.club.exception.HeadNotSameException
 import com.msg.gcms.domain.user.domain.entity.User
 import com.msg.gcms.domain.user.domain.repository.UserRepository
 import com.msg.gcms.domain.user.exception.UserNotFoundException
+import com.msg.gcms.global.fcm.enums.SendType
+import com.msg.gcms.global.util.MessageSendUtil
 import com.msg.gcms.global.util.UserUtil
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -23,7 +25,8 @@ class RejectApplicantServiceImpl(
     private val clubRepository: ClubRepository,
     private val userRepository: UserRepository,
     private val applicantRepository: ApplicantRepository,
-    private val userUtil: UserUtil
+    private val userUtil: UserUtil,
+    private val messageSendUtil: MessageSendUtil
 ) : RejectApplicantService {
     override fun execute(clubId: Long, rejectDto: RejectDto) {
         val clubInfo: Club = clubRepository.findByIdOrNull(clubId)
@@ -41,5 +44,7 @@ class RejectApplicantServiceImpl(
             ?: throw NotApplicantException()
 
         applicantRepository.delete(applicant)
+
+        messageSendUtil.send(applicantUser, "동아리 신청 거절", "${clubInfo.name}에 거절되셨습니다.", SendType.CLUB)
     }
 }

--- a/src/main/kotlin/com/msg/gcms/domain/auth/presentation/data/dto/SignInDto.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/auth/presentation/data/dto/SignInDto.kt
@@ -1,5 +1,6 @@
 package com.msg.gcms.domain.auth.presentation.data.dto
 
 data class SignInDto(
-    val code: String
+    val code: String,
+    val token: String?,
 )

--- a/src/main/kotlin/com/msg/gcms/domain/auth/presentation/data/request/SignInRequestDto.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/auth/presentation/data/request/SignInRequestDto.kt
@@ -1,5 +1,6 @@
 package com.msg.gcms.domain.auth.presentation.data.request
 
 data class SignInRequestDto(
-    val code: String
+    val code: String,
+    val token: String?
 )

--- a/src/main/kotlin/com/msg/gcms/domain/auth/util/AuthUtil.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/auth/util/AuthUtil.kt
@@ -7,9 +7,9 @@ import gauth.GAuthUserInfo
 
 interface AuthUtil {
 
-    fun saveNewUser(gAuthUserInfo: GAuthUserInfo, refreshToken: String)
+    fun saveNewUser(gAuthUserInfo: GAuthUserInfo, refreshToken: String, token: String?)
 
-    fun saveNewAdmin(gAuthUserInfo: GAuthUserInfo, refreshToken: String)
+    fun saveNewAdmin(gAuthUserInfo: GAuthUserInfo, refreshToken: String, token: String?)
 
-    fun saveNewRefreshToken(userInfo: User, refreshToken: String): RefreshToken
+    fun saveNewRefreshToken(userInfo: User, refreshToken: String, token: String?): RefreshToken
 }

--- a/src/main/kotlin/com/msg/gcms/domain/auth/util/impl/AuthConverterImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/auth/util/impl/AuthConverterImpl.kt
@@ -14,7 +14,8 @@ import java.util.*
 class AuthConverterImpl : AuthConverter {
     override fun toDto(signInRequestDto: SignInRequestDto): SignInDto =
         SignInDto(
-            code = signInRequestDto.code
+            code = signInRequestDto.code,
+            token = signInRequestDto.token
         )
 
 

--- a/src/main/kotlin/com/msg/gcms/domain/auth/util/impl/AuthUtilImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/auth/util/impl/AuthUtilImpl.kt
@@ -4,7 +4,9 @@ import com.msg.gcms.domain.auth.domain.entity.RefreshToken
 import com.msg.gcms.domain.auth.domain.repository.RefreshTokenRepository
 import com.msg.gcms.domain.auth.util.AuthConverter
 import com.msg.gcms.domain.auth.util.AuthUtil
+import com.msg.gcms.domain.user.domain.entity.DeviceToken
 import com.msg.gcms.domain.user.domain.entity.User
+import com.msg.gcms.domain.user.domain.repository.DeviceTokenRepository
 import com.msg.gcms.domain.user.domain.repository.UserRepository
 import gauth.GAuthUserInfo
 import org.springframework.stereotype.Component
@@ -14,22 +16,24 @@ class AuthUtilImpl(
     private val refreshTokenRepository: RefreshTokenRepository,
     private val authConverter: AuthConverter,
     private val userRepository: UserRepository,
+    private val deviceTokenRepository: DeviceTokenRepository
 ) : AuthUtil {
 
-    override fun saveNewUser(gAuthUserInfo: GAuthUserInfo, refreshToken: String) {
+    override fun saveNewUser(gAuthUserInfo: GAuthUserInfo, refreshToken: String, token: String?) {
         val signInUserInfo: User = authConverter.toEntity(gAuthUserInfo)
             .let { userRepository.save(it) }
-        authConverter.toEntity(signInUserInfo, refreshToken)
-            .let { refreshTokenRepository.save(it) }
+        saveNewRefreshToken(signInUserInfo, refreshToken, token)
     }
 
-    override fun saveNewAdmin(gAuthUserInfo: GAuthUserInfo, refreshToken: String) {
+    override fun saveNewAdmin(gAuthUserInfo: GAuthUserInfo, refreshToken: String, token: String?) {
         val signInAdminInfo: User = authConverter.toAdminEntity(gAuthUserInfo)
             .let { userRepository.save(it) }
-        saveNewRefreshToken(signInAdminInfo, refreshToken)
+        saveNewRefreshToken(signInAdminInfo, refreshToken, token)
     }
 
-    override fun saveNewRefreshToken(userInfo: User, refreshToken: String): RefreshToken =
-        authConverter.toEntity(userInfo, refreshToken)
+    override fun saveNewRefreshToken(userInfo: User, refreshToken: String, token: String?): RefreshToken {
+        deviceTokenRepository.save(DeviceToken(userInfo.id, userInfo, token ?: ""))
+        return authConverter.toEntity(userInfo, refreshToken)
             .let { refreshTokenRepository.save(it) }
+    }
 }

--- a/src/main/kotlin/com/msg/gcms/domain/clubMember/service/impl/DelegateHeadServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/clubMember/service/impl/DelegateHeadServiceImpl.kt
@@ -11,6 +11,8 @@ import com.msg.gcms.domain.clubMember.service.DelegateHeadService
 import com.msg.gcms.domain.clubMember.util.UpdateClubHeadUtil
 import com.msg.gcms.domain.user.domain.repository.UserRepository
 import com.msg.gcms.domain.user.exception.UserNotFoundException
+import com.msg.gcms.global.fcm.enums.SendType
+import com.msg.gcms.global.util.MessageSendUtil
 import com.msg.gcms.global.util.UserUtil
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -23,7 +25,8 @@ class DelegateHeadServiceImpl(
     private val clubMemberRepository: ClubMemberRepository,
     private val userRepository: UserRepository,
     private val updateClubHeadUtil: UpdateClubHeadUtil,
-    private val userUtil: UserUtil
+    private val userUtil: UserUtil,
+    private val messageSendUtil: MessageSendUtil
 ) : DelegateHeadService {
     override fun execute(clubId: Long, delegateHeadDto: DelegateHeadDto): ChangeHeadDto {
         val club = (clubRepository.findByIdOrNull(clubId)
@@ -37,6 +40,7 @@ class DelegateHeadServiceImpl(
             .find { it.user.id == delegateHeadDto.uuid }
             ?: throw NotClubMemberException()
         updateClubHeadUtil.updateClubHead(club, clubMember, user)
+        messageSendUtil.send(clubMember.user, "부장 위임", "${club.name}의 부장으로 위임되셨습니다.", SendType.CLUB)
         return ChangeHeadDto(clubMember.user, user)
     }
 }

--- a/src/main/kotlin/com/msg/gcms/domain/clubMember/service/impl/ExitClubMemberServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/clubMember/service/impl/ExitClubMemberServiceImpl.kt
@@ -10,6 +10,8 @@ import com.msg.gcms.domain.clubMember.exception.ClubMemberExitOneSelfException
 import com.msg.gcms.domain.clubMember.exception.ClubMemberReleaseNotFoundException
 import com.msg.gcms.domain.clubMember.presentation.data.dto.ClubMemberExitDto
 import com.msg.gcms.domain.clubMember.service.ExitClubMemberService
+import com.msg.gcms.global.fcm.enums.SendType
+import com.msg.gcms.global.util.MessageSendUtil
 import com.msg.gcms.global.util.UserUtil
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -20,7 +22,8 @@ import org.springframework.transaction.annotation.Transactional
 class ExitClubMemberServiceImpl(
     private val userUtil: UserUtil,
     private val clubRepository: ClubRepository,
-    private val clubMemberRepository: ClubMemberRepository
+    private val clubMemberRepository: ClubMemberRepository,
+    private val messageSendUtil: MessageSendUtil
 ) : ExitClubMemberService {
     override fun execute(clubMemberExitDto: ClubMemberExitDto) {
         val user = userUtil.fetchCurrentUser()
@@ -34,6 +37,7 @@ class ExitClubMemberServiceImpl(
         }
         val memberRelease: ClubMember = getClubMemberToRelease(club, clubMemberExitDto.uuid)
         clubMemberRepository.delete(memberRelease)
+        messageSendUtil.send(memberRelease.user, "동아리 방출", "${club.name}에서 방출당했습니다.", SendType.CLUB)
     }
 
     private fun getClubMemberToRelease(club: Club, uuid: String): ClubMember =

--- a/src/main/kotlin/com/msg/gcms/domain/user/domain/entity/DeviceToken.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/user/domain/entity/DeviceToken.kt
@@ -1,0 +1,18 @@
+package com.msg.gcms.domain.user.domain.entity
+
+import java.util.UUID
+import javax.persistence.*
+
+
+@Entity
+class DeviceToken (
+    @Id
+    val userId: UUID,
+
+    @MapsId
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
+    val user: User,
+
+    val token: String,
+)

--- a/src/main/kotlin/com/msg/gcms/domain/user/domain/entity/User.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/user/domain/entity/User.kt
@@ -47,7 +47,9 @@ class User(
 
     @JsonIgnore
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
-    val clubMember: List<ClubMember> = listOf()
+    val clubMember: List<ClubMember> = listOf(),
+
+    val fcmToken: String = "",
 ) {
     fun updateProfileImg(profileImg: String?) {
         this.profileImg = profileImg

--- a/src/main/kotlin/com/msg/gcms/domain/user/domain/entity/User.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/user/domain/entity/User.kt
@@ -48,8 +48,6 @@ class User(
     @JsonIgnore
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
     val clubMember: List<ClubMember> = listOf(),
-
-    val fcmToken: String = "",
 ) {
     fun updateProfileImg(profileImg: String?) {
         this.profileImg = profileImg

--- a/src/main/kotlin/com/msg/gcms/domain/user/domain/repository/DeviceTokenRepository.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/user/domain/repository/DeviceTokenRepository.kt
@@ -1,0 +1,8 @@
+package com.msg.gcms.domain.user.domain.repository
+
+import com.msg.gcms.domain.user.domain.entity.DeviceToken
+import org.springframework.data.repository.CrudRepository
+import java.util.UUID
+
+interface DeviceTokenRepository: CrudRepository<DeviceToken, UUID> {
+}

--- a/src/main/kotlin/com/msg/gcms/domain/user/exception/DeviceTokenNotFoundException.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/user/exception/DeviceTokenNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.msg.gcms.domain.user.exception
+
+import com.msg.gcms.global.exception.ErrorCode
+import com.msg.gcms.global.exception.exceptions.BasicException
+
+class DeviceTokenNotFoundException : BasicException(ErrorCode.DEVICE_TOKEN_NOT_FOUND)

--- a/src/main/kotlin/com/msg/gcms/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/msg/gcms/global/exception/ErrorCode.kt
@@ -26,6 +26,7 @@ enum class ErrorCode(
     CLUB_MEMBER_RELEASE_NOT_FOUND("방출하려는 유저가 존재하지 않는 경우", 404),
     USER_NOT_FOUND("해당 유저를 찾을 수 없음", 404),
     CLUB_NOT_FOUND("해당 동아리를 찾을 수 없음", 404),
+    DEVICE_TOKEN_NOT_FOUND("디바이스 토큰을 찾을 수 없음", 404),
 
     ALREADY_CLUB_EXIST("해당 동아리가 이미 존재함", 409),
 

--- a/src/main/kotlin/com/msg/gcms/global/fcm/FcmConfig.kt
+++ b/src/main/kotlin/com/msg/gcms/global/fcm/FcmConfig.kt
@@ -1,0 +1,38 @@
+package com.msg.gcms.global.fcm
+
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+import java.io.ByteArrayInputStream
+import java.io.FileInputStream
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+import javax.annotation.PostConstruct
+
+
+@Configuration
+class FcmConfig(
+    @Value("\${fcm.value}")
+    private val fcmValue: String
+) {
+
+    @PostConstruct
+    private fun initialize() {
+        try {
+            if (FirebaseApp.getApps().isEmpty()) {
+                val options: FirebaseOptions = FirebaseOptions.builder()
+                    .setCredentials(
+                        GoogleCredentials.fromStream(
+                            FileInputStream(fcmValue)
+                        )
+                    )
+                    .build()
+                FirebaseApp.initializeApp(options)
+            }
+        } catch (e: IOException) {
+            e.printStackTrace()
+        }
+    }
+}

--- a/src/main/kotlin/com/msg/gcms/global/fcm/enums/SendType.kt
+++ b/src/main/kotlin/com/msg/gcms/global/fcm/enums/SendType.kt
@@ -1,0 +1,5 @@
+package com.msg.gcms.global.fcm.enums
+
+enum class SendType {
+    CLUB
+}

--- a/src/main/kotlin/com/msg/gcms/global/util/MessageSendUtil.kt
+++ b/src/main/kotlin/com/msg/gcms/global/util/MessageSendUtil.kt
@@ -1,8 +1,10 @@
 package com.msg.gcms.global.util
 
+import com.msg.gcms.domain.user.domain.entity.User
 import com.msg.gcms.global.fcm.enums.SendType
 import java.util.*
 
 interface MessageSendUtil {
-    fun sendMessage(token: String, title: String, content: String, type: SendType, identify: UUID?)
+    fun sendMessage(token: String, title: String, content: String, type: SendType)
+    fun send(user: User, title: String, content: String, type: SendType)
 }

--- a/src/main/kotlin/com/msg/gcms/global/util/MessageSendUtil.kt
+++ b/src/main/kotlin/com/msg/gcms/global/util/MessageSendUtil.kt
@@ -1,0 +1,8 @@
+package com.msg.gcms.global.util
+
+import com.msg.gcms.global.fcm.enums.SendType
+import java.util.*
+
+interface MessageSendUtil {
+    fun sendMessage(token: String, title: String, content: String, type: SendType, identify: UUID?)
+}

--- a/src/main/kotlin/com/msg/gcms/global/util/impl/MessageSendUtilImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/global/util/impl/MessageSendUtilImpl.kt
@@ -1,0 +1,31 @@
+package com.msg.gcms.global.util.impl
+
+import com.google.firebase.messaging.*
+import com.msg.gcms.global.fcm.enums.SendType
+import com.msg.gcms.global.util.MessageSendUtil
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class MessageSendUtilImpl : MessageSendUtil {
+    override fun sendMessage(token: String, title: String, content: String, type: SendType, identify: UUID?) {
+        val message = Message.builder()
+            .setToken(token)
+            .putData("type", type.name)
+            .putData("identify", identify.toString())
+            .setNotification(
+                Notification.builder()
+                    .setTitle(title)
+                    .setBody(content)
+                    .build()
+            )
+            .setApnsConfig(
+                ApnsConfig.builder()
+                    .setAps(Aps.builder().setSound("default").build())
+                    .build()
+            )
+            .build()
+
+        FirebaseMessaging.getInstance().sendAsync(message)
+    }
+}

--- a/src/main/kotlin/com/msg/gcms/global/util/impl/MessageSendUtilImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/global/util/impl/MessageSendUtilImpl.kt
@@ -1,18 +1,22 @@
 package com.msg.gcms.global.util.impl
 
 import com.google.firebase.messaging.*
+import com.msg.gcms.domain.user.domain.entity.User
+import com.msg.gcms.domain.user.domain.repository.DeviceTokenRepository
+import com.msg.gcms.domain.user.exception.DeviceTokenNotFoundException
 import com.msg.gcms.global.fcm.enums.SendType
 import com.msg.gcms.global.util.MessageSendUtil
 import org.springframework.stereotype.Component
 import java.util.*
 
 @Component
-class MessageSendUtilImpl : MessageSendUtil {
-    override fun sendMessage(token: String, title: String, content: String, type: SendType, identify: UUID?) {
+class MessageSendUtilImpl(
+    private val deviceTokenRepository: DeviceTokenRepository,
+) : MessageSendUtil {
+    override fun sendMessage(token: String, title: String, content: String, type: SendType) {
         val message = Message.builder()
             .setToken(token)
             .putData("type", type.name)
-            .putData("identify", identify.toString())
             .setNotification(
                 Notification.builder()
                     .setTitle(title)
@@ -27,5 +31,12 @@ class MessageSendUtilImpl : MessageSendUtil {
             .build()
 
         FirebaseMessaging.getInstance().sendAsync(message)
+    }
+
+    override fun send(user: User, title: String, content: String, type: SendType) {
+        val deviceToken = deviceTokenRepository.findById(user.id)
+            .orElseThrow { throw DeviceTokenNotFoundException() }
+        println("deviceToken.token = ${deviceToken.token}")
+        sendMessage(deviceToken.token, title, content, type)
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,3 +54,5 @@ logging:
       amazonaws:
         util:
           EC2MetadataUtils: error
+fcm:
+  value: ${FCM_VALUE}

--- a/src/test/kotlin/com/msg/gcms/domain/applicant/service/AcceptApplicantServiceTest.kt
+++ b/src/test/kotlin/com/msg/gcms/domain/applicant/service/AcceptApplicantServiceTest.kt
@@ -9,6 +9,7 @@ import com.msg.gcms.domain.club.domain.repository.ClubRepository
 import com.msg.gcms.domain.clubMember.domain.entity.ClubMember
 import com.msg.gcms.domain.clubMember.domain.repository.ClubMemberRepository
 import com.msg.gcms.domain.user.domain.repository.UserRepository
+import com.msg.gcms.global.util.MessageSendUtil
 import com.msg.gcms.global.util.UserUtil
 import com.msg.gcms.testUtils.TestUtils
 import io.kotest.core.spec.style.BehaviorSpec
@@ -26,6 +27,7 @@ class AcceptApplicantServiceTest : BehaviorSpec({
     val userRepository = mockk<UserRepository>()
     val applicantConverter = mockk<ApplicantConverter>()
     val userUtil = mockk<UserUtil>()
+    val messageSendUtil = mockk<MessageSendUtil>()
 
     val acceptApplicantService = AcceptApplicantServiceImpl(
         clubRepository = clubRepository,
@@ -33,7 +35,8 @@ class AcceptApplicantServiceTest : BehaviorSpec({
         applicantRepository = applicantRepository,
         clubMemberRepository = clubMemberRepository,
         userRepository = userRepository,
-        userUtil = userUtil
+        userUtil = userUtil,
+        messageSendUtil = messageSendUtil
     )
 
     given("동아리 ID와 유저가 주어졌을때") {

--- a/src/test/kotlin/com/msg/gcms/domain/applicant/service/ClubApplyServiceTest.kt
+++ b/src/test/kotlin/com/msg/gcms/domain/applicant/service/ClubApplyServiceTest.kt
@@ -12,6 +12,7 @@ import com.msg.gcms.domain.club.exception.ClubNotFoundException
 import com.msg.gcms.domain.clubMember.domain.entity.ClubMember
 import com.msg.gcms.domain.clubMember.domain.repository.ClubMemberRepository
 import com.msg.gcms.domain.user.domain.entity.User
+import com.msg.gcms.global.util.MessageSendUtil
 import com.msg.gcms.global.util.UserUtil
 import com.msg.gcms.testUtils.TestUtils
 import io.kotest.assertions.throwables.shouldThrow
@@ -27,8 +28,9 @@ class ClubApplyServiceTest : BehaviorSpec({
     val clubMemberRepository = mockk<ClubMemberRepository>()
     val applicantRepository = mockk<ApplicantRepository>()
     val applicantSaveUtil = mockk<ApplicantSaveUtil>()
+    val messageSendUtil = mockk<MessageSendUtil>()
 
-    val clubApplyServiceImpl = ClubApplyServiceImpl(userUtil, clubRepository, clubMemberRepository, applicantSaveUtil, applicantRepository)
+    val clubApplyServiceImpl = ClubApplyServiceImpl(userUtil, clubRepository, clubMemberRepository, applicantSaveUtil, applicantRepository, messageSendUtil)
 
     given("유저와 동아리가 주어지고"){
         val user = TestUtils.TestDataUtil.user().entity()

--- a/src/test/kotlin/com/msg/gcms/domain/applicant/service/RejectApplicantServiceTest.kt
+++ b/src/test/kotlin/com/msg/gcms/domain/applicant/service/RejectApplicantServiceTest.kt
@@ -9,6 +9,7 @@ import com.msg.gcms.domain.club.domain.repository.ClubRepository
 import com.msg.gcms.domain.clubMember.domain.entity.ClubMember
 import com.msg.gcms.domain.clubMember.domain.repository.ClubMemberRepository
 import com.msg.gcms.domain.user.domain.repository.UserRepository
+import com.msg.gcms.global.util.MessageSendUtil
 import com.msg.gcms.global.util.UserUtil
 import com.msg.gcms.testUtils.TestUtils
 import io.kotest.core.spec.style.BehaviorSpec
@@ -25,12 +26,14 @@ class RejectApplicantServiceTest : BehaviorSpec({
     val userRepository = mockk<UserRepository>()
     val applicantConverter = mockk<ApplicantConverter>()
     val userUtil = mockk<UserUtil>()
+    val messageSendUtil = mockk<MessageSendUtil>()
 
     val rejectApplicantService = RejectApplicantServiceImpl(
         clubRepository = clubRepository,
         applicantRepository = applicantRepository,
         userRepository = userRepository,
-        userUtil = userUtil
+        userUtil = userUtil,
+        messageSendUtil = messageSendUtil
     )
 
     given("동아리 ID와 유저가 주어졌을때") {

--- a/src/test/kotlin/com/msg/gcms/domain/clubmember/service/DelegateHeadServiceTest.kt
+++ b/src/test/kotlin/com/msg/gcms/domain/clubmember/service/DelegateHeadServiceTest.kt
@@ -9,6 +9,7 @@ import com.msg.gcms.domain.clubMember.presentation.data.dto.DelegateHeadDto
 import com.msg.gcms.domain.clubMember.service.impl.DelegateHeadServiceImpl
 import com.msg.gcms.domain.clubMember.util.UpdateClubHeadUtil
 import com.msg.gcms.domain.user.domain.repository.UserRepository
+import com.msg.gcms.global.util.MessageSendUtil
 import com.msg.gcms.global.util.UserUtil
 import com.msg.gcms.testUtils.TestUtils
 import io.kotest.core.spec.style.BehaviorSpec
@@ -23,7 +24,8 @@ class DelegateHeadServiceTest : BehaviorSpec({
     val userRepository = mockk<UserRepository>()
     val clubMemberRepository = mockk<ClubMemberRepository>()
     val updateClubHeadUtil = mockk<UpdateClubHeadUtil>()
-    val delegateHeadServiceImpl = DelegateHeadServiceImpl(clubRepository, clubMemberRepository, userRepository, updateClubHeadUtil, userUtil)
+    val messageSendUtil = mockk<MessageSendUtil>()
+    val delegateHeadServiceImpl = DelegateHeadServiceImpl(clubRepository, clubMemberRepository, userRepository, updateClubHeadUtil, userUtil, messageSendUtil)
     given("동아리, 부장, 동아리 멤버가 주어지고"){
         val head = TestUtils.data().user().entity()
         val member = TestUtils.data().user().entity()

--- a/src/test/kotlin/com/msg/gcms/domain/clubmember/service/ExitClubMemberTest.kt
+++ b/src/test/kotlin/com/msg/gcms/domain/clubmember/service/ExitClubMemberTest.kt
@@ -7,6 +7,7 @@ import com.msg.gcms.domain.clubMember.domain.repository.ClubMemberRepository
 import com.msg.gcms.domain.clubMember.exception.ClubMemberExitOneSelfException
 import com.msg.gcms.domain.clubMember.presentation.data.dto.ClubMemberExitDto
 import com.msg.gcms.domain.clubMember.service.impl.ExitClubMemberServiceImpl
+import com.msg.gcms.global.util.MessageSendUtil
 import com.msg.gcms.global.util.UserUtil
 import com.msg.gcms.testUtils.TestUtils
 import io.kotest.assertions.throwables.shouldThrow
@@ -20,7 +21,8 @@ class ExitClubMemberTest : BehaviorSpec({
     val userUtil = mockk<UserUtil>()
     val clubRepository = mockk<ClubRepository>()
     val clubMemberRepository = mockk<ClubMemberRepository>()
-    val exitClubMemberService = ExitClubMemberServiceImpl(userUtil, clubRepository, clubMemberRepository)
+    val messageSendUtil = mockk<MessageSendUtil>()
+    val exitClubMemberService = ExitClubMemberServiceImpl(userUtil, clubRepository, clubMemberRepository, messageSendUtil)
 
     Given("clubMemberExitDto 주어졌을때") {
         val user = (1..2)


### PR DESCRIPTION
## 💡 개요
* fcm 푸시 알람 개발

## 📃 작업내용
* 동아리 신청시 해당 동아리의 부장한테 알림
* 동아리 신청 수락시 수락당한 유저한테 알림
* 동아리 신청 거절시 거절당한 유저한테 알림
* 동아리 개설 승인시 개설한 유저한테 알림
* 동아리 개설 거절시 거절당한 유저한테 알림
* 동아리 강퇴 당했을때 강퇴당한 유저한테 알림
* 동아리 부장에 위임당했을때 위임당한 유저한테 알림

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
* 로그인 될때마다 디바이스 토큰 바꿔서 조금 이슈인거 같긴함
