### PR TITLE
🔀 :: 201 - 유저 검색시 어드민 검색 불가로 만들기

### DIFF
--- a/src/main/kotlin/com/msg/gcms/domain/user/service/impl/SearchUserServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/user/service/impl/SearchUserServiceImpl.kt
@@ -1,15 +1,12 @@
 package com.msg.gcms.domain.user.service.impl
 
-import com.msg.gcms.domain.club.domain.repository.ClubRepository
 import com.msg.gcms.domain.club.enums.ClubType
-import com.msg.gcms.domain.user.domain.entity.User
 import com.msg.gcms.domain.user.domain.repository.UserRepository
 import com.msg.gcms.domain.user.presentaion.data.dto.SearchRequirementDto
 import com.msg.gcms.domain.user.presentaion.data.dto.SearchUserDto
 import com.msg.gcms.domain.user.service.SearchUserService
 import com.msg.gcms.domain.user.utils.UserConverter
 import com.msg.gcms.domain.user.utils.UserValidator
-import com.msg.gcms.global.util.UserUtil
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 

--- a/src/main/kotlin/com/msg/gcms/domain/user/service/impl/SearchUserServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/user/service/impl/SearchUserServiceImpl.kt
@@ -8,33 +8,28 @@ import com.msg.gcms.domain.user.presentaion.data.dto.SearchRequirementDto
 import com.msg.gcms.domain.user.presentaion.data.dto.SearchUserDto
 import com.msg.gcms.domain.user.service.SearchUserService
 import com.msg.gcms.domain.user.utils.UserConverter
+import com.msg.gcms.domain.user.utils.UserValidator
 import com.msg.gcms.global.util.UserUtil
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class SearchUserServiceImpl(
-    val userUtil: UserUtil,
+    val userValidator: UserValidator,
     val userRepository: UserRepository,
-    val clubRepository: ClubRepository,
     val userConverter: UserConverter,
 ) : SearchUserService {
     @Transactional(readOnly = true, rollbackFor = [Exception::class])
     override fun execute(dto: SearchRequirementDto): List<SearchUserDto> {
-        val user = userUtil.fetchCurrentUser()
-        return if (dto.clubType != ClubType.MAJOR
-            && dto.clubType != ClubType.FREEDOM
+        return if (dto.clubType == ClubType.EDITORIAL
         ) {
             userRepository.findByNicknameContaining(dto.name)
-                .filter { it.id != user.id }
+                .let { userValidator.validateUser(it, dto.clubType) }
                 .map { userConverter.toDto(it) }
         } else {
             userRepository.findUserNotJoin(dto.clubType, dto.name)
-                .filter { !verifyUserIsHead(it, dto.clubType) }
-                .filter { it.id != user.id }
+                .let { userValidator.validateUser(it, dto.clubType) }
                 .map { userConverter.toDto(it) }
-        } 
+        }
     }
-    private fun verifyUserIsHead(user: User, type: ClubType): Boolean =
-        clubRepository.existsByUserAndType(user, type)
 }

--- a/src/main/kotlin/com/msg/gcms/domain/user/utils/UserValidator.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/user/utils/UserValidator.kt
@@ -1,0 +1,8 @@
+package com.msg.gcms.domain.user.utils
+
+import com.msg.gcms.domain.club.enums.ClubType
+import com.msg.gcms.domain.user.domain.entity.User
+
+interface UserValidator {
+   fun validateUser(userList: List<User>, clubType: ClubType): List<User>
+}

--- a/src/main/kotlin/com/msg/gcms/domain/user/utils/impl/UserValidatorImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/user/utils/impl/UserValidatorImpl.kt
@@ -1,0 +1,44 @@
+package com.msg.gcms.domain.user.utils.impl
+
+import com.msg.gcms.domain.auth.domain.Role
+import com.msg.gcms.domain.club.domain.repository.ClubRepository
+import com.msg.gcms.domain.club.enums.ClubType
+import com.msg.gcms.domain.user.domain.entity.User
+import com.msg.gcms.domain.user.utils.UserValidator
+import com.msg.gcms.global.util.UserUtil
+import org.springframework.stereotype.Component
+
+@Component
+class UserValidatorImpl(
+    private val userUtil: UserUtil,
+    private val clubRepository: ClubRepository
+) : UserValidator{
+    override fun validateUser(userList: List<User>, clubType: ClubType): List<User> {
+        return if(clubType == ClubType.EDITORIAL) {
+            verifyUser(userList)
+        } else {
+            verifyUser(userList)
+                .filter { !verifyUserIsHead(it, clubType) }
+        }
+    }
+
+    private fun verifyUser(userList: List<User>): List<User> {
+        return userList
+            .filter { verifyUserIsStudent(it) }
+            .filter { checkUserNotSameCurrentUser(it) }
+    }
+
+    private fun verifyUserIsHead(user: User, type: ClubType): Boolean =
+        clubRepository.existsByUserAndType(user, type)
+
+
+    private fun verifyUserIsStudent(user: User): Boolean =
+        user.roles.equals(Role.ROLE_STUDENT)
+
+
+    private fun checkUserNotSameCurrentUser(user: User): Boolean {
+        val currentUser = userUtil.fetchCurrentUser()
+
+        return user.id != currentUser.id
+    }
+}

--- a/src/test/kotlin/com/msg/gcms/domain/user/service/SearchUserServiceTest.kt
+++ b/src/test/kotlin/com/msg/gcms/domain/user/service/SearchUserServiceTest.kt
@@ -6,6 +6,7 @@ import com.msg.gcms.domain.user.domain.repository.UserRepository
 import com.msg.gcms.domain.user.presentaion.data.dto.SearchRequirementDto
 import com.msg.gcms.domain.user.service.impl.SearchUserServiceImpl
 import com.msg.gcms.domain.user.utils.UserConverter
+import com.msg.gcms.domain.user.utils.UserValidator
 import com.msg.gcms.domain.user.utils.impl.UserConverterImpl
 import com.msg.gcms.global.util.UserUtil
 import com.msg.gcms.testUtils.TestUtils
@@ -23,9 +24,9 @@ class SearchUserServiceTest : BehaviorSpec({
         return UserConverterImpl()
     }
     val userRepository = mockk<UserRepository>()
-    val userUtil = mockk<UserUtil>()
-    val clubRepository = mockk<ClubRepository>()
-    val searchUserServiceImpl = SearchUserServiceImpl(userUtil, userRepository, clubRepository, userConverter())
+    val userValidator = mockk<UserValidator>()
+
+    val searchUserServiceImpl = SearchUserServiceImpl(userValidator, userRepository, userConverter())
 
     given("search user With Type Is MAJOR OR FREEDOM") {
         val size = (1..100).random()
@@ -39,7 +40,6 @@ class SearchUserServiceTest : BehaviorSpec({
 
         `when`("is invoked") {
             every { userRepository.findUserNotJoin(type, name) } returns user
-            every { clubRepository.existsByUserAndType(any(), type) } returns false
             val result = searchUserServiceImpl.execute(dto)
 
             then("result should not be null") {


### PR DESCRIPTION
## 💡 개요
유저 검색시 어드민까지 검색되는 문제를 해결
## 📃 작업내용
* validator 생성
* 유저 검증로직 리팩토링
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
