### PR TITLE
🔀 :: 224 - 동아리 제목에 콜론(:)이 들어갈때 엑셀로 뽑으면 에러

### DIFF
--- a/src/main/kotlin/com/msg/gcms/domain/admin/service/impl/CreateClubMemberExcelServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/admin/service/impl/CreateClubMemberExcelServiceImpl.kt
@@ -32,7 +32,7 @@ class CreateClubMemberExcelServiceImpl(
                     dataLists.add(listOf("${index + 1}", "${it.grade}${it.classNum}${if (it.number <= 9) "0" else ""}${it.number}", it.nickname))
                 }
                 lists.add(dataLists)
-                clubNames.add(club.name)
+                clubNames.add(club.name.replace(":", " "))
             }
         return excelUtil.createExcel(clubNames, head, lists)
     }


### PR DESCRIPTION
## 💡 개요
* 동아리 제목에 콘론이 들어가고 동아리별로 엑셀을 만들면 에러

## 📃 작업내용
* 동아리 제목에 콜론이 들어가면 엑셀로 뽑을때 공백으로 치환하도록 변경

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
