### PR TITLE
🔀 :: 241 - 정규식 수정

### DIFF
--- a/src/main/kotlin/com/msg/gcms/domain/club/presentation/data/request/CreateClubRequest.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/presentation/data/request/CreateClubRequest.kt
@@ -20,7 +20,7 @@ data class CreateClubRequest(
     @field:NotBlank
     val contact: String,
     @field:NotBlank
-    @field:Pattern(regexp = "^(http|https)://")
+    @field:Pattern(regexp = "^((http(s?))\\:\\/\\/)([0-9a-zA-Z\\-]+\\.)+[a-zA-Z]{2,6}(\\:[0-9]+)?(\\/\\S*)?\$")
     val notionLink: String,
     val teacher: String? = null,
     @field:NotNull

--- a/src/main/kotlin/com/msg/gcms/domain/club/presentation/data/request/UpdateClubRequest.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/presentation/data/request/UpdateClubRequest.kt
@@ -17,7 +17,7 @@ data class UpdateClubRequest (
     @field:NotBlank
     val contact: String,
     @field:NotBlank
-    @field:Pattern(regexp = "^(http|https)://")
+    @field:Pattern(regexp = "^((http(s?))\\:\\/\\/)([0-9a-zA-Z\\-]+\\.)+[a-zA-Z]{2,6}(\\:[0-9]+)?(\\/\\S*)?\$")
     val notionLink: String,
     val teacher: String? = null,
     @field:NotNull


### PR DESCRIPTION
## 💡 개요
notionLink 정규식 수정
## 📃 작업내용
http:// 또는 https:// 만 허용하던 정규식을 http:// 와 https:// 로 시작하는 url을 허용하는 정규식으로 수정했습니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
