### PR TITLE
🔀 Feat/print operation plan

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
 	implementation("org.apache.poi:poi-ooxml:5.2.2")
 	implementation("com.google.firebase:firebase-admin:7.3.0")
 	implementation("com.squareup.okhttp3:okhttp:4.10.0")
+	implementation("kr.dogfoot:hwplib:1.1.1")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/com/msg/gcms/domain/admin/presentation/AdminController.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/admin/presentation/AdminController.kt
@@ -83,4 +83,6 @@ class AdminController(
             .let { adminConverter.toResponse(it) }
             .let { ResponseEntity.ok().body(it) }
 
+    @GetMapping("/hwp/operation/{club_id}")
+    fun 
 }

--- a/src/main/kotlin/com/msg/gcms/domain/admin/presentation/AdminController.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/admin/presentation/AdminController.kt
@@ -28,7 +28,8 @@ class AdminController(
     private val rejectClubService: RejectClubService,
     private val findAllUserListService: FindAllUserListService,
     private val userDetailInfoService: UserDetailInfoService,
-    private val findAllStatisticsService: FindAllStatisticsService
+    private val findAllStatisticsService: FindAllStatisticsService,
+    private val clubOperationPlanHwpService: ClubOperationPlanHwpService
 ) {
 
     @GetMapping("/excel/club")
@@ -84,5 +85,8 @@ class AdminController(
             .let { ResponseEntity.ok().body(it) }
 
     @GetMapping("/hwp/operation/{club_id}")
-    fun 
+    fun getOperationPlanToHwp(@PathVariable("club_id") clubId: Long, response: HttpServletResponse): ByteArray {
+        response.setHeader("Content-Disposition", "attachment; filename=club.xlsx")
+        return clubOperationPlanHwpService.execute(clubId)
+    }
 }

--- a/src/main/kotlin/com/msg/gcms/domain/admin/service/ClubOperationPlanHwpService.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/admin/service/ClubOperationPlanHwpService.kt
@@ -1,0 +1,5 @@
+package com.msg.gcms.domain.admin.service
+
+interface ClubOperationPlanHwpService {
+    fun execute(clubId: Long): ByteArray
+}

--- a/src/main/kotlin/com/msg/gcms/domain/admin/service/impl/ClubOperationPlanHwpServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/admin/service/impl/ClubOperationPlanHwpServiceImpl.kt
@@ -30,29 +30,29 @@ class ClubOperationPlanHwpServiceImpl(
         val operationPlan = operationPlanRepository.findByIdOrNull(clubId) ?: throw OperationPlanNotFoundException()
         val user: User = club.user
 
-        hwpUtil.findCellByFieldName(hwpFile, "분야", operationPlan.field)
-        hwpUtil.findCellByFieldName(hwpFile, "동아리 장소", operationPlan.place)
-        hwpUtil.findCellByFieldName(hwpFile, "동아리명", club.name)
-        hwpUtil.findCellByFieldName(hwpFile, "지도교사", club.teacher)
+        hwpUtil.insertByFieldName(hwpFile, "분야", operationPlan.field)
+        hwpUtil.insertByFieldName(hwpFile, "동아리 장소", operationPlan.place)
+        hwpUtil.insertByFieldName(hwpFile, "동아리명", club.name)
+        hwpUtil.insertByFieldName(hwpFile, "지도교사", club.teacher)
 
-        hwpUtil.findCellByFieldName(hwpFile, "학번 이름1", sortNameAndNum(user))
-        hwpUtil.findCellByFieldName(hwpFile, "담당역할1", "부장")
+        hwpUtil.insertByFieldName(hwpFile, "학번 이름1", sortNameAndNum(user))
+        hwpUtil.insertByFieldName(hwpFile, "담당역할1", "부장")
 
         for(i in 2..12) {
             val member = club.clubMember[i - 2].user
-            hwpUtil.findCellByFieldName(hwpFile, "학번 이름${i}", sortNameAndNum(member))
-            hwpUtil.findCellByFieldName(hwpFile, "담당역할${i}", "")
+            hwpUtil.insertByFieldName(hwpFile, "학번 이름${i}", sortNameAndNum(member))
+            hwpUtil.insertByFieldName(hwpFile, "담당역할${i}", "")
         }
 
-        hwpUtil.findCellByFieldName(hwpFile, "연구주제", operationPlan.subject)
-        hwpUtil.findCellByFieldName(hwpFile, "연구내용", operationPlan.content)
-        hwpUtil.findCellByFieldName(hwpFile, "동아리 운영 규칙", operationPlan.rule)
+        hwpUtil.insertByFieldName(hwpFile, "연구주제", operationPlan.subject)
+        hwpUtil.insertByFieldName(hwpFile, "연구내용", operationPlan.content)
+        hwpUtil.insertByFieldName(hwpFile, "동아리 운영 규칙", operationPlan.rule)
 
 
         operationPlan.monthlyPlan
             .map {
-                hwpUtil.findCellByFieldName(hwpFile, "${it.month}월 개요", it.summaryPlan)
-                hwpUtil.findCellByFieldName(hwpFile, "${it.month}월 연구 내용", it.plan)
+                hwpUtil.insertByFieldName(hwpFile, "${it.month}월 개요", it.summaryPlan)
+                hwpUtil.insertByFieldName(hwpFile, "${it.month}월 연구 내용", it.plan)
         }
 
         val outPutStream = ByteArrayOutputStream()

--- a/src/main/kotlin/com/msg/gcms/domain/admin/service/impl/ClubOperationPlanHwpServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/admin/service/impl/ClubOperationPlanHwpServiceImpl.kt
@@ -39,8 +39,7 @@ class ClubOperationPlanHwpServiceImpl(
         hwpUtil.insertByFieldName(hwpFile, "담당역할1", "부장")
 
         for(i in 2..12) {
-            val member = club.clubMember[i - 2].user
-            hwpUtil.insertByFieldName(hwpFile, "학번 이름${i}", sortNameAndNum(member))
+            hwpUtil.insertByFieldName(hwpFile, "학번 이름${i}", sortNameAndNum(club.clubMember[i - 2].user))
             hwpUtil.insertByFieldName(hwpFile, "담당역할${i}", "")
         }
 

--- a/src/main/kotlin/com/msg/gcms/domain/admin/service/impl/ClubOperationPlanHwpServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/admin/service/impl/ClubOperationPlanHwpServiceImpl.kt
@@ -21,7 +21,7 @@ class ClubOperationPlanHwpServiceImpl(
     private val operationPlanRepository: OperationPlanRepository,
     private val hwpProperties: HwpProperties,
     private val hwpUtil: HwpUtil
-): ClubOperationPlanHwpService {
+) : ClubOperationPlanHwpService {
     override fun execute(clubId: Long): ByteArray {
         val hwpUrl = hwpProperties.url
         val hwpFile = hwpUtil.readFile(hwpUrl)

--- a/src/main/kotlin/com/msg/gcms/domain/admin/service/impl/ClubOperationPlanHwpServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/admin/service/impl/ClubOperationPlanHwpServiceImpl.kt
@@ -1,0 +1,71 @@
+package com.msg.gcms.domain.admin.service.impl
+
+import com.msg.gcms.domain.admin.service.ClubOperationPlanHwpService
+import com.msg.gcms.domain.club.domain.repository.ClubRepository
+import com.msg.gcms.domain.club.domain.repository.OperationPlanRepository
+import com.msg.gcms.domain.club.exception.ClubNotFoundException
+import com.msg.gcms.domain.club.exception.OperationPlanNotFoundException
+import com.msg.gcms.domain.user.domain.entity.User
+import com.msg.gcms.global.util.HwpUtil
+import com.msg.gcms.global.util.properties.HwpProperties
+import kr.dogfoot.hwplib.writer.HWPWriter
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.io.ByteArrayOutputStream
+
+@Service
+@Transactional(readOnly = true)
+class ClubOperationPlanHwpServiceImpl(
+    private val clubRepository: ClubRepository,
+    private val operationPlanRepository: OperationPlanRepository,
+    private val hwpProperties: HwpProperties,
+    private val hwpUtil: HwpUtil
+): ClubOperationPlanHwpService {
+    override fun execute(clubId: Long): ByteArray {
+        val hwpUrl = hwpProperties.url
+        val hwpFile = hwpUtil.readFile(hwpUrl)
+
+        val club = clubRepository.findByIdOrNull(clubId) ?: throw ClubNotFoundException()
+        val operationPlan = operationPlanRepository.findByIdOrNull(clubId) ?: throw OperationPlanNotFoundException()
+        val user: User = club.user
+
+        hwpUtil.findCellByFieldName(hwpFile, "분야", operationPlan.field)
+        hwpUtil.findCellByFieldName(hwpFile, "동아리 장소", operationPlan.place)
+        hwpUtil.findCellByFieldName(hwpFile, "동아리명", club.name)
+        hwpUtil.findCellByFieldName(hwpFile, "지도교사", club.teacher)
+
+        hwpUtil.findCellByFieldName(hwpFile, "학번 이름1", sortNameAndNum(user))
+        hwpUtil.findCellByFieldName(hwpFile, "담당역할1", "부장")
+
+        for(i in 2..12) {
+            val member = club.clubMember[i - 2].user
+            hwpUtil.findCellByFieldName(hwpFile, "학번 이름${i}", sortNameAndNum(member))
+            hwpUtil.findCellByFieldName(hwpFile, "담당역할${i}", "")
+        }
+
+        hwpUtil.findCellByFieldName(hwpFile, "연구주제", operationPlan.subject)
+        hwpUtil.findCellByFieldName(hwpFile, "연구내용", operationPlan.content)
+        hwpUtil.findCellByFieldName(hwpFile, "동아리 운영 규칙", operationPlan.rule)
+
+
+        operationPlan.monthlyPlan
+            .map {
+                hwpUtil.findCellByFieldName(hwpFile, "${it.month}월 개요", it.summaryPlan)
+                hwpUtil.findCellByFieldName(hwpFile, "${it.month}월 연구 내용", it.plan)
+        }
+
+        val outPutStream = ByteArrayOutputStream()
+
+        HWPWriter.toStream(hwpFile, outPutStream)
+        return outPutStream.toByteArray()
+    }
+
+    private fun sortNameAndNum(user: User): String =
+        "${user.nickname}${user.grade}${user.classNum}${
+            when(user.number) {
+                in 1..10 -> "0${user.number}"
+                else -> "${user.number}"
+            }
+        }"
+}

--- a/src/main/kotlin/com/msg/gcms/domain/club/domain/entity/Club.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/domain/entity/Club.kt
@@ -55,7 +55,7 @@ class Club(
     @Enumerated(value = EnumType.STRING)
     val clubStatus: ClubStatus = ClubStatus.PENDING,
 
-    @OneToOne(fetch = FetchType.LAZY, mappedBy = "club")
-    @MapsId
+    @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.REMOVE])
+    @JoinColumn(name = "operation_plan_id")
     val operationPlan: OperationPlan? = null
 )

--- a/src/main/kotlin/com/msg/gcms/domain/club/domain/entity/MonthlyPlan.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/domain/entity/MonthlyPlan.kt
@@ -14,5 +14,7 @@ class MonthlyPlan(
 
     val month: Long,
 
+    val planSummary: String,
+
     val plan: String
 )

--- a/src/main/kotlin/com/msg/gcms/domain/club/domain/entity/MonthlyPlan.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/domain/entity/MonthlyPlan.kt
@@ -14,7 +14,7 @@ class MonthlyPlan(
 
     val month: Long,
 
-    val planSummary: String,
+    val summaryPlan: String,
 
     val plan: String
 )

--- a/src/main/kotlin/com/msg/gcms/domain/club/domain/entity/OperationPlan.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/domain/entity/OperationPlan.kt
@@ -18,6 +18,8 @@ class OperationPlan(
 
     val rule: String,
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "operation_plan", cascade = [CascadeType.REMOVE])
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = [CascadeType.REMOVE])
+    @JoinColumn(name = "monthly_plan_id")
     val monthlyPlan: List<MonthlyPlan>
 )

--- a/src/main/kotlin/com/msg/gcms/domain/club/exception/OperationPlanNotFoundException.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/exception/OperationPlanNotFoundException.kt
@@ -3,5 +3,5 @@ package com.msg.gcms.domain.club.exception
 import com.msg.gcms.global.exception.ErrorCode
 import com.msg.gcms.global.exception.exceptions.BasicException
 
-class OperationPlanNotFoundException: BasicException(ErrorCode.OPERATION_PLAN_NOT_FOUND) {
+class OperationPlanNotFoundException : BasicException(ErrorCode.OPERATION_PLAN_NOT_FOUND) {
 }

--- a/src/main/kotlin/com/msg/gcms/domain/club/exception/OperationPlanNotFoundException.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/exception/OperationPlanNotFoundException.kt
@@ -1,0 +1,7 @@
+package com.msg.gcms.domain.club.exception
+
+import com.msg.gcms.global.exception.ErrorCode
+import com.msg.gcms.global.exception.exceptions.BasicException
+
+class OperationPlanNotFoundException: BasicException(ErrorCode.OPERATION_PLAN_NOT_FOUND) {
+}

--- a/src/main/kotlin/com/msg/gcms/domain/club/presentation/data/dto/OperationPlanDto.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/presentation/data/dto/OperationPlanDto.kt
@@ -18,10 +18,13 @@ data class OperationPlanDto(
     data class MonthlyPlanDto(
         val month: Long,
 
+        val summaryPlan: String,
+
         val plan: String
     ) {
         constructor(createMonthlyPlanRequest: CreateOperationPlanRequest.CreateMonthlyPlanRequest): this(
             month = createMonthlyPlanRequest.month,
+            summaryPlan = createMonthlyPlanRequest.summaryPlan,
             plan = createMonthlyPlanRequest.plan
         )
     }

--- a/src/main/kotlin/com/msg/gcms/domain/club/presentation/data/request/CreateOperationPlanRequest.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/presentation/data/request/CreateOperationPlanRequest.kt
@@ -16,6 +16,8 @@ data class CreateOperationPlanRequest(
     data class CreateMonthlyPlanRequest(
         val month: Long,
 
+        val summaryPlan: String,
+
         val plan: String
     )
 }

--- a/src/main/kotlin/com/msg/gcms/domain/club/service/impl/CreateOperationPlanServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/service/impl/CreateOperationPlanServiceImpl.kt
@@ -21,7 +21,7 @@ class CreateOperationPlanServiceImpl(
     private val monthlyPlanRepository: MonthlyPlanRepository,
     private val clubRepository: ClubRepository,
     private val operationPlanConverter: OperationPlanConverter
-): CreateOperationPlanService {
+) : CreateOperationPlanService {
     override fun execute(clubId: Long, operationPlanDto: OperationPlanDto) {
         val foundClub: Club = clubRepository.findByIdOrNull(clubId) ?: throw ClubNotFoundException()
         val monthlyPlan = operationPlanDto.monthlyPlan

--- a/src/main/kotlin/com/msg/gcms/domain/club/service/impl/CreateOperationPlanServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/club/service/impl/CreateOperationPlanServiceImpl.kt
@@ -8,7 +8,6 @@ import com.msg.gcms.domain.club.domain.repository.MonthlyPlanRepository
 import com.msg.gcms.domain.club.domain.repository.OperationPlanRepository
 import com.msg.gcms.domain.club.exception.ClubNotFoundException
 import com.msg.gcms.domain.club.presentation.data.dto.OperationPlanDto
-import com.msg.gcms.domain.club.presentation.data.request.CreateOperationPlanRequest
 import com.msg.gcms.domain.club.service.CreateOperationPlanService
 import com.msg.gcms.domain.club.utils.OperationPlanConverter
 import org.springframework.data.repository.findByIdOrNull
@@ -28,6 +27,7 @@ class CreateOperationPlanServiceImpl(
         val monthlyPlan = operationPlanDto.monthlyPlan
                 .map { MonthlyPlan(
                     month = it.month,
+                    summaryPlan = it.summaryPlan,
                     plan = it.plan
                 ) }
 

--- a/src/main/kotlin/com/msg/gcms/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/msg/gcms/global/exception/ErrorCode.kt
@@ -31,6 +31,7 @@ enum class ErrorCode(
     CLUB_MEMBER_RELEASE_NOT_FOUND("방출하려는 유저가 존재하지 않는 경우", 404),
     USER_NOT_FOUND("해당 유저를 찾을 수 없음", 404),
     CLUB_NOT_FOUND("해당 동아리를 찾을 수 없음", 404),
+    OPERATION_PLAN_NOT_FOUND("해당 운영계획서를 찾을 수 없음", 404),
     DEVICE_TOKEN_NOT_FOUND("디바이스 토큰을 찾을 수 없음", 404),
 
     ALREADY_CLUB_EXIST("해당 동아리가 이미 존재함", 409),

--- a/src/main/kotlin/com/msg/gcms/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/msg/gcms/global/security/SecurityConfig.kt
@@ -78,6 +78,7 @@ class SecurityConfig(
             .antMatchers(HttpMethod.PATCH, "/admin/{club_id}").hasRole("ADMIN")
             .antMatchers(HttpMethod.DELETE, "/admin/{club_id}").hasRole("ADMIN")
             .antMatchers(HttpMethod.GET, "/admin/club/statistics").hasRole("ADMIN")
+            .antMatchers(HttpMethod.GET, "/admin/hwp/operation/{club_id}").hasRole("ADMIN")
 
             .anyRequest().denyAll()
             .and()

--- a/src/main/kotlin/com/msg/gcms/global/util/HwpUtil.kt
+++ b/src/main/kotlin/com/msg/gcms/global/util/HwpUtil.kt
@@ -1,0 +1,9 @@
+package com.msg.gcms.global.util
+
+import kr.dogfoot.hwplib.`object`.HWPFile
+
+interface HwpUtil {
+    fun readFile(url: String): HWPFile
+
+    fun findCellByFieldName(hwpFile: HWPFile, index: Int, fieldName: String, content: String)
+}

--- a/src/main/kotlin/com/msg/gcms/global/util/HwpUtil.kt
+++ b/src/main/kotlin/com/msg/gcms/global/util/HwpUtil.kt
@@ -5,5 +5,5 @@ import kr.dogfoot.hwplib.`object`.HWPFile
 interface HwpUtil {
     fun readFile(url: String): HWPFile
 
-    fun findCellByFieldName(hwpFile: HWPFile, fieldName: String, content: String?)
+    fun insertByFieldName(hwpFile: HWPFile, fieldName: String, content: String?)
 }

--- a/src/main/kotlin/com/msg/gcms/global/util/HwpUtil.kt
+++ b/src/main/kotlin/com/msg/gcms/global/util/HwpUtil.kt
@@ -5,5 +5,5 @@ import kr.dogfoot.hwplib.`object`.HWPFile
 interface HwpUtil {
     fun readFile(url: String): HWPFile
 
-    fun findCellByFieldName(hwpFile: HWPFile, index: Int, fieldName: String, content: String)
+    fun findCellByFieldName(hwpFile: HWPFile, index: Int, fieldName: String, content: String?)
 }

--- a/src/main/kotlin/com/msg/gcms/global/util/HwpUtil.kt
+++ b/src/main/kotlin/com/msg/gcms/global/util/HwpUtil.kt
@@ -5,5 +5,5 @@ import kr.dogfoot.hwplib.`object`.HWPFile
 interface HwpUtil {
     fun readFile(url: String): HWPFile
 
-    fun findCellByFieldName(hwpFile: HWPFile, index: Int, fieldName: String, content: String?)
+    fun findCellByFieldName(hwpFile: HWPFile, fieldName: String, content: String?)
 }

--- a/src/main/kotlin/com/msg/gcms/global/util/impl/HwpUtilImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/global/util/impl/HwpUtilImpl.kt
@@ -12,12 +12,12 @@ class HwpUtilImpl: HwpUtil {
     override fun readFile(url: String): HWPFile =
         HWPReader.fromURL(url)
 
-    override fun findCellByFieldName(hwpFile: HWPFile, index: Int, fieldName: String, content: String) {
+    override fun findCellByFieldName(hwpFile: HWPFile, index: Int, fieldName: String, content: String?) {
         CellFinder.findAll(hwpFile, fieldName)
             .map {
                 val para = it.paragraphList.getParagraph(index)
                 para.text ?: para.createText()
-                para.text.addString(content)
+                para.text.addString(content ?: "")
             }
     }
 }

--- a/src/main/kotlin/com/msg/gcms/global/util/impl/HwpUtilImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/global/util/impl/HwpUtilImpl.kt
@@ -12,10 +12,10 @@ class HwpUtilImpl: HwpUtil {
     override fun readFile(url: String): HWPFile =
         HWPReader.fromURL(url)
 
-    override fun findCellByFieldName(hwpFile: HWPFile, index: Int, fieldName: String, content: String?) {
+    override fun findCellByFieldName(hwpFile: HWPFile, fieldName: String, content: String?) {
         CellFinder.findAll(hwpFile, fieldName)
             .map {
-                val para = it.paragraphList.getParagraph(index)
+                val para = it.paragraphList.getParagraph(0)
                 para.text ?: para.createText()
                 para.text.addString(content ?: "")
             }

--- a/src/main/kotlin/com/msg/gcms/global/util/impl/HwpUtilImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/global/util/impl/HwpUtilImpl.kt
@@ -1,0 +1,23 @@
+package com.msg.gcms.global.util.impl
+
+import com.msg.gcms.global.util.HwpUtil
+import kr.dogfoot.hwplib.`object`.HWPFile
+import kr.dogfoot.hwplib.`object`.bodytext.paragraph.text.ParaText
+import kr.dogfoot.hwplib.reader.HWPReader
+import kr.dogfoot.hwplib.tool.objectfinder.CellFinder
+import org.springframework.stereotype.Component
+
+@Component
+class HwpUtilImpl: HwpUtil {
+    override fun readFile(url: String): HWPFile =
+        HWPReader.fromURL(url)
+
+    override fun findCellByFieldName(hwpFile: HWPFile, index: Int, fieldName: String, content: String) {
+        CellFinder.findAll(hwpFile, fieldName)
+            .map {
+                val para = it.paragraphList.getParagraph(index)
+                para.text ?: para.createText()
+                para.text.addString(content)
+            }
+    }
+}

--- a/src/main/kotlin/com/msg/gcms/global/util/impl/HwpUtilImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/global/util/impl/HwpUtilImpl.kt
@@ -7,7 +7,7 @@ import kr.dogfoot.hwplib.tool.objectfinder.CellFinder
 import org.springframework.stereotype.Component
 
 @Component
-class HwpUtilImpl: HwpUtil {
+class HwpUtilImpl : HwpUtil {
     override fun readFile(url: String): HWPFile =
         HWPReader.fromURL(url)
 

--- a/src/main/kotlin/com/msg/gcms/global/util/impl/HwpUtilImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/global/util/impl/HwpUtilImpl.kt
@@ -2,7 +2,6 @@ package com.msg.gcms.global.util.impl
 
 import com.msg.gcms.global.util.HwpUtil
 import kr.dogfoot.hwplib.`object`.HWPFile
-import kr.dogfoot.hwplib.`object`.bodytext.paragraph.text.ParaText
 import kr.dogfoot.hwplib.reader.HWPReader
 import kr.dogfoot.hwplib.tool.objectfinder.CellFinder
 import org.springframework.stereotype.Component
@@ -12,7 +11,7 @@ class HwpUtilImpl: HwpUtil {
     override fun readFile(url: String): HWPFile =
         HWPReader.fromURL(url)
 
-    override fun findCellByFieldName(hwpFile: HWPFile, fieldName: String, content: String?) {
+    override fun insertByFieldName(hwpFile: HWPFile, fieldName: String, content: String?) {
         CellFinder.findAll(hwpFile, fieldName)
             .map {
                 val para = it.paragraphList.getParagraph(0)

--- a/src/main/kotlin/com/msg/gcms/global/util/properties/HwpProperties.kt
+++ b/src/main/kotlin/com/msg/gcms/global/util/properties/HwpProperties.kt
@@ -1,0 +1,10 @@
+package com.msg.gcms.global.util.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "hwp.file")
+class HwpProperties(
+    val url: String
+)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,3 +60,7 @@ fcm:
 discord:
   webhook:
     url: ${DISCORD_WEBHOOK_URL}
+
+hwp:
+  file:
+    url: ${HWP_FILE_URL}


### PR DESCRIPTION
## 💡 개요
동아리 정보와 따로 입력받은 운영계획서용 엔티티의 데이터들을 불러와 한글 파일에 채워서 반환하는 api를 만들었습니다
## 📃 작업내용

## 🔀 변경사항
월별 계획(MonthlyPlan)엔티티의 컬럼이 새로 하나 추가되었어요!!(월별 계획 개요)
## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
코드가 더럽더라도.. 너그러이 이해해주시길..🤢