### PR TITLE
🔀 :: 267 - jar 이름 설정하는 부분 제거

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,9 +61,3 @@ tasks.withType<KotlinCompile> {
 tasks.withType<Test> {
 	useJUnitPlatform()
 }
-tasks {
-	val customBootJarName = "testApplication.jar"
-	named<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
-		archiveFileName.set(customBootJarName)
-	}
-}


### PR DESCRIPTION
## 💡 개요
* [build.gradle 파일에 추가](https://github.com/GSM-MSG/GCMS-BackEnd/commit/d91ed310b912a47db69cd0994ecc0ca1f85a5410)된 jar 네이밍 수정하는 부분 제거

## 📃 작업내용
* build.gradle에서 jar 네이밍 수정하는 부분 제거

## 🎸 기타
* 죄송합니다...😭
