### PR TITLE
🔀 :: 321 공지사항 업데이트 API

### DIFF
--- a/src/main/kotlin/com/msg/gcms/domain/notice/presentation/NoticeController.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/notice/presentation/NoticeController.kt
@@ -1,12 +1,10 @@
 package com.msg.gcms.domain.notice.presentation
 
 import com.msg.gcms.domain.notice.presentation.data.request.CreateNoticeRequestDto
+import com.msg.gcms.domain.notice.presentation.data.request.UpdateNoticeRequestDto
 import com.msg.gcms.domain.notice.presentation.data.response.FindNoticeDetailResponseDto
 import com.msg.gcms.domain.notice.presentation.data.response.NoticeListResponseDto
-import com.msg.gcms.domain.notice.service.CreateNoticeService
-import com.msg.gcms.domain.notice.service.DeleteNoticeService
-import com.msg.gcms.domain.notice.service.FindNoticeDetailService
-import com.msg.gcms.domain.notice.service.NoticeListService
+import com.msg.gcms.domain.notice.service.*
 import com.msg.gcms.domain.notice.utils.NoticeConverter
 import com.msg.gcms.global.annotation.RequestController
 import org.springframework.http.HttpStatus
@@ -20,7 +18,8 @@ class NoticeController(
     private val noticeConverter: NoticeConverter,
     private val deleteNoticeService: DeleteNoticeService,
     private val findNoticeDetailService: FindNoticeDetailService,
-    private val noticeListService: NoticeListService
+    private val noticeListService: NoticeListService,
+    private val updateNoticeService: UpdateNoticeService
 ) {
     @PostMapping("/{club_id}")
     fun createNotice(
@@ -51,4 +50,13 @@ class NoticeController(
     ): ResponseEntity<NoticeListResponseDto> =
         noticeListService.execute(clubId)
             .let { ResponseEntity.ok().body(noticeConverter.toResponse(it)) }
+
+    @PatchMapping("/{id}")
+    fun updateNotice(
+        @PathVariable id: Long,
+        @RequestBody @Valid updateNoticeRequestDto: UpdateNoticeRequestDto
+    ) : ResponseEntity<Unit> =
+        noticeConverter.toDto(updateNoticeRequestDto)
+            .let { updateNoticeService.execute(id, it) }
+            .let { ResponseEntity.status(HttpStatus.NO_CONTENT).build() }
 }

--- a/src/main/kotlin/com/msg/gcms/domain/notice/presentation/data/dto/UpdateNoticeDto.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/notice/presentation/data/dto/UpdateNoticeDto.kt
@@ -1,0 +1,6 @@
+package com.msg.gcms.domain.notice.presentation.data.dto
+
+data class UpdateNoticeDto(
+    val title: String,
+    val content: String
+)

--- a/src/main/kotlin/com/msg/gcms/domain/notice/presentation/data/request/UpdateNoticeRequestDto.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/notice/presentation/data/request/UpdateNoticeRequestDto.kt
@@ -1,0 +1,14 @@
+package com.msg.gcms.domain.notice.presentation.data.request
+
+import org.hibernate.validator.constraints.Length
+import javax.validation.constraints.NotBlank
+
+data class UpdateNoticeRequestDto(
+    @field:NotBlank
+    @field:Length(max = 100)
+    val title: String,
+
+    @field:NotBlank
+    @field:Length(max = 2000)
+    val content: String
+)

--- a/src/main/kotlin/com/msg/gcms/domain/notice/service/UpdateNoticeService.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/notice/service/UpdateNoticeService.kt
@@ -1,0 +1,7 @@
+package com.msg.gcms.domain.notice.service
+
+import com.msg.gcms.domain.notice.presentation.data.dto.UpdateNoticeDto
+
+interface UpdateNoticeService {
+    fun execute(id: Long, dto: UpdateNoticeDto)
+}

--- a/src/main/kotlin/com/msg/gcms/domain/notice/service/impl/UpdateNoticeServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/notice/service/impl/UpdateNoticeServiceImpl.kt
@@ -1,0 +1,40 @@
+package com.msg.gcms.domain.notice.service.impl
+
+import com.msg.gcms.domain.auth.domain.Role
+import com.msg.gcms.domain.club.exception.HeadNotSameException
+import com.msg.gcms.domain.notice.domain.entity.Notice
+import com.msg.gcms.domain.notice.domain.repository.NoticeRepository
+import com.msg.gcms.domain.notice.exception.NoticeNotFoundException
+import com.msg.gcms.domain.notice.presentation.data.dto.UpdateNoticeDto
+import com.msg.gcms.domain.notice.service.UpdateNoticeService
+import com.msg.gcms.global.annotation.ServiceWithTransaction
+import com.msg.gcms.global.util.UserUtil
+import org.springframework.data.repository.findByIdOrNull
+
+@ServiceWithTransaction
+class UpdateNoticeServiceImpl(
+    private val userUtil: UserUtil,
+    private val noticeRepository: NoticeRepository
+) : UpdateNoticeService {
+    override fun execute(id: Long, dto: UpdateNoticeDto) {
+        val user = userUtil.fetchCurrentUser()
+
+        val notice = noticeRepository.findByIdOrNull(id)
+            ?: throw NoticeNotFoundException()
+
+        if(user.roles[0] == Role.ROLE_STUDENT) {
+            if (user != notice.club.user) throw HeadNotSameException()
+        }
+
+        val updatedNotice = Notice(
+            id = notice.id,
+            title = dto.title,
+            content = notice.content,
+            club = notice.club,
+            user = notice.user,
+            createdAt = notice.createdAt,
+        )
+
+        noticeRepository.save(updatedNotice)
+    }
+}

--- a/src/main/kotlin/com/msg/gcms/domain/notice/utils/NoticeConverter.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/notice/utils/NoticeConverter.kt
@@ -3,7 +3,9 @@ package com.msg.gcms.domain.notice.utils
 import com.msg.gcms.domain.club.domain.entity.Club
 import com.msg.gcms.domain.notice.domain.entity.Notice
 import com.msg.gcms.domain.notice.presentation.data.dto.NoticeDto
+import com.msg.gcms.domain.notice.presentation.data.dto.UpdateNoticeDto
 import com.msg.gcms.domain.notice.presentation.data.request.CreateNoticeRequestDto
+import com.msg.gcms.domain.notice.presentation.data.request.UpdateNoticeRequestDto
 import com.msg.gcms.domain.notice.presentation.data.response.FindNoticeDetailResponseDto
 import com.msg.gcms.domain.notice.presentation.data.response.NoticeListDto
 import com.msg.gcms.domain.notice.presentation.data.response.NoticeListResponseDto
@@ -11,12 +13,15 @@ import com.msg.gcms.domain.user.domain.entity.User
 
 interface NoticeConverter {
     fun toDto(requestDto: CreateNoticeRequestDto): NoticeDto
-    fun toResponse(notice: Notice): FindNoticeDetailResponseDto
     fun toEntity(dto: NoticeDto, user: User, club: Club): Notice
 
     fun toDto(entity: Notice): NoticeListDto.NoticeResponseDto
 
+    fun toDto(requestDto: UpdateNoticeRequestDto): UpdateNoticeDto
+
     fun toListDto(dto: List<NoticeListDto.NoticeResponseDto>): NoticeListDto
 
     fun toResponse(dto: NoticeListDto): NoticeListResponseDto
+
+    fun toResponse(notice: Notice): FindNoticeDetailResponseDto
 }

--- a/src/main/kotlin/com/msg/gcms/domain/notice/utils/impl/NoticeConverterImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/notice/utils/impl/NoticeConverterImpl.kt
@@ -3,7 +3,9 @@ package com.msg.gcms.domain.notice.utils.impl
 import com.msg.gcms.domain.club.domain.entity.Club
 import com.msg.gcms.domain.notice.domain.entity.Notice
 import com.msg.gcms.domain.notice.presentation.data.dto.NoticeDto
+import com.msg.gcms.domain.notice.presentation.data.dto.UpdateNoticeDto
 import com.msg.gcms.domain.notice.presentation.data.request.CreateNoticeRequestDto
+import com.msg.gcms.domain.notice.presentation.data.request.UpdateNoticeRequestDto
 import com.msg.gcms.domain.notice.presentation.data.response.FindNoticeDetailResponseDto
 import com.msg.gcms.domain.notice.presentation.data.response.NoticeListDto
 import com.msg.gcms.domain.notice.presentation.data.response.NoticeListResponseDto
@@ -18,20 +20,18 @@ class NoticeConverterImpl : NoticeConverter {
         content = requestDto.content
     )
 
-    override fun toResponse(notice: Notice): FindNoticeDetailResponseDto = FindNoticeDetailResponseDto(
-        title = notice.title,
-        content = notice.content,
-        username = notice.user.nickname,
-        userProfileImg = notice.user.profileImg,
-        createdAt = notice.createdAt
-    )
-
     override fun toDto(entity: Notice): NoticeListDto.NoticeResponseDto = NoticeListDto.NoticeResponseDto(
         id = entity.id,
         title = entity.title,
         username = entity.user.nickname,
         createdAt = entity.createdAt
     )
+
+    override fun toDto(requestDto: UpdateNoticeRequestDto): UpdateNoticeDto =
+        UpdateNoticeDto(
+            title = requestDto.title,
+            content = requestDto.content
+        )
 
     override fun toEntity(dto: NoticeDto, user: User, club: Club): Notice = Notice(
         id = dto.id,
@@ -42,6 +42,7 @@ class NoticeConverterImpl : NoticeConverter {
         club = club
     )
 
+
     override fun toListDto(dto: List<NoticeListDto.NoticeResponseDto>): NoticeListDto =
          NoticeListDto(
             notices = dto
@@ -51,4 +52,13 @@ class NoticeConverterImpl : NoticeConverter {
             NoticeListResponseDto(
                     notices = dto.notices
             )
+
+    override fun toResponse(notice: Notice): FindNoticeDetailResponseDto = FindNoticeDetailResponseDto(
+        title = notice.title,
+        content = notice.content,
+        username = notice.user.nickname,
+        userProfileImg = notice.user.profileImg,
+        createdAt = notice.createdAt
+    )
+
 }

--- a/src/main/kotlin/com/msg/gcms/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/msg/gcms/global/security/SecurityConfig.kt
@@ -50,6 +50,7 @@ class SecurityConfig(
             .antMatchers(HttpMethod.GET, "/notification/{id}").authenticated()
             .antMatchers(HttpMethod.DELETE, "/notification/{id}").authenticated()
             .antMatchers(HttpMethod.GET, "/notification/{club_id}/all").authenticated()
+            .antMatchers(HttpMethod.PATCH, "/notification/{id}").authenticated()
 
             .antMatchers(HttpMethod.GET, "/club-member/{club_id}").authenticated()
             .antMatchers(HttpMethod.POST, "/club-member/{club_id}").authenticated()


### PR DESCRIPTION
## 💡 개요
공지사항을 업데이트 하는 API를 작성하였습니다
## 📃 작업내용
삭제 API와 동일하게 해당 동아리의 부장 또는 선생님만 공지를 수정할 수 있도록 하였습니다