### PR TITLE
요청한 날짜와 교시에 이미 스케쥴이 존재하면 예외 발생

### DIFF
--- a/src/main/kotlin/com/msg/gcms/domain/attendance/exception/AlreadyScheduleExistException.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/attendance/exception/AlreadyScheduleExistException.kt
@@ -1,0 +1,6 @@
+package com.msg.gcms.domain.attendance.exception
+
+import com.msg.gcms.global.exception.ErrorCode
+import com.msg.gcms.global.exception.exceptions.BasicException
+
+class AlreadyScheduleExistException : BasicException(ErrorCode.ALREADY_SCHEDULE_EXIST)

--- a/src/main/kotlin/com/msg/gcms/domain/attendance/presentation/data/request/CreateScheduleRequestDto.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/attendance/presentation/data/request/CreateScheduleRequestDto.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat
 import com.msg.gcms.domain.attendance.domain.enums.Period
 import java.time.LocalDate
 import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotEmpty
 import javax.validation.constraints.NotNull
 
 data class CreateScheduleRequestDto(
@@ -14,5 +15,6 @@ data class CreateScheduleRequestDto(
     val date: LocalDate,
 
     @field:NotNull
+    @field:NotEmpty
     val periods: List<Period>
 )

--- a/src/main/kotlin/com/msg/gcms/domain/attendance/repository/CustomScheduleRepository.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/attendance/repository/CustomScheduleRepository.kt
@@ -1,9 +1,11 @@
 package com.msg.gcms.domain.attendance.repository
 
 import com.msg.gcms.domain.attendance.domain.entity.Schedule
+import com.msg.gcms.domain.attendance.domain.enums.Period
 import com.msg.gcms.domain.club.domain.entity.Club
 import java.time.LocalDate
 
 interface CustomScheduleRepository {
     fun queryByDate(club: Club, date: LocalDate?): Schedule?
+    fun existByDateAndPeriod(date: LocalDate, period: Period): Boolean
 }

--- a/src/main/kotlin/com/msg/gcms/domain/attendance/repository/impl/CustomScheduleRepositoryImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/attendance/repository/impl/CustomScheduleRepositoryImpl.kt
@@ -1,7 +1,9 @@
 package com.msg.gcms.domain.attendance.repository.impl
 
+import com.msg.gcms.domain.attendance.domain.entity.QAttendance.attendance
 import com.msg.gcms.domain.attendance.domain.entity.QSchedule.schedule
 import com.msg.gcms.domain.attendance.domain.entity.Schedule
+import com.msg.gcms.domain.attendance.domain.enums.Period
 import com.msg.gcms.domain.attendance.repository.CustomScheduleRepository
 import com.msg.gcms.domain.club.domain.entity.Club
 import com.querydsl.core.types.dsl.BooleanExpression
@@ -18,6 +20,19 @@ class CustomScheduleRepositoryImpl(
                 dateEq(date)
             ).fetchOne()
     }
+
+    override fun existByDateAndPeriod(date: LocalDate, period: Period): Boolean {
+        return jpaQueryFactory.selectOne()
+            .from(attendance)
+            .where(
+                attendance.schedule.date.eq(date),
+                attendance.period.eq(period)
+            )
+            .fetchFirst() != null
+    }
+
+
+
 
     private fun dateEq(date: LocalDate?): BooleanExpression =
         schedule.date.eq(date ?: LocalDate.now())

--- a/src/main/kotlin/com/msg/gcms/domain/attendance/service/impl/CreateScheduleServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/attendance/service/impl/CreateScheduleServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.msg.gcms.domain.attendance.service.impl
 
+import com.msg.gcms.domain.attendance.exception.AlreadyScheduleExistException
 import com.msg.gcms.domain.attendance.presentation.data.dto.ScheduleDto.ScheduleListDto
 import com.msg.gcms.domain.attendance.repository.AttendanceRepository
 import com.msg.gcms.domain.attendance.repository.ScheduleRepository
@@ -31,6 +32,9 @@ class CreateScheduleServiceImpl(
             .let { scheduleRepository.save(it) }
 
         val attendances = dto.period.flatMap { period ->
+            if(scheduleRepository.existByDateAndPeriod(dto.schedule.date, period))
+                throw AlreadyScheduleExistException()
+
             members.map { member ->
                 attendanceConverter.toEntity(
                     schedule = schedule,

--- a/src/main/kotlin/com/msg/gcms/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/msg/gcms/global/exception/ErrorCode.kt
@@ -40,6 +40,7 @@ enum class ErrorCode(
     NOTICE_NOT_FOUND("해당 공지를 찾을 수 없음", 404),
 
     ALREADY_CLUB_EXIST("해당 동아리가 이미 존재함", 409),
+    ALREADY_SCHEDULE_EXIST("해당 동아리가 이미 존재함", 409),
     OPENING_APPLICATION_ALREADY_EXIST("이미 개설신청서를 제출하였습니다.", 409),
 
     INTERNAL_SERVER_ERROR("서버 내부 에러", 500),

--- a/src/main/kotlin/com/msg/gcms/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/msg/gcms/global/exception/ErrorCode.kt
@@ -40,7 +40,7 @@ enum class ErrorCode(
     NOTICE_NOT_FOUND("해당 공지를 찾을 수 없음", 404),
 
     ALREADY_CLUB_EXIST("해당 동아리가 이미 존재함", 409),
-    ALREADY_SCHEDULE_EXIST("해당 동아리가 이미 존재함", 409),
+    ALREADY_SCHEDULE_EXIST("같은 날짜와 교시에 해당하는 스케쥴이 이미 존재함", 409),
     OPENING_APPLICATION_ALREADY_EXIST("이미 개설신청서를 제출하였습니다.", 409),
 
     INTERNAL_SERVER_ERROR("서버 내부 에러", 500),


### PR DESCRIPTION
## 💡 배경 및 개요

요청한 날짜와 교시에 이미 스케쥴이 존재하면 예외를 발생시키도록 변경했습니다.

Resolves: #325

## 📃 작업내용

- 요청한 날짜와 교시에 이미 스케쥴이 존재하면 예외가 발생하도록 변경했습니다.
- querydsl limit 1로 성능을 최적화했습니다
- request body의 period 리스트가 비어있으면 400 예외가 발생하도록 변경했습니다.

## 🙋‍♂️ 리뷰노트

감사합니다

## ✅ PR 체크리스트

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타