### PR TITLE
🔀 :: 330 로그인 API 리팩토링

### DIFF
--- a/src/main/kotlin/com/msg/gcms/domain/auth/service/impl/SignInServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/auth/service/impl/SignInServiceImpl.kt
@@ -25,7 +25,6 @@ class SignInServiceImpl(
     private val authUtil: AuthUtil,
 ) : SignInService {
 
-
     override fun execute(signInDto: SignInDto): SignInResponseDto {
         val gAuthToken: GAuthToken = gAuth.generateToken(
             signInDto.code,
@@ -34,7 +33,7 @@ class SignInServiceImpl(
             gAuthProperties.redirectUri
         )
         val gAuthUserInfo: GAuthUserInfo = gAuth.getUserInfo(gAuthToken.accessToken)
-        val role = getRoleByGauthInfo(gAuthUserInfo.role, gAuthUserInfo.email)
+        val role = getRoleByGAuthInfo(gAuthUserInfo.role, gAuthUserInfo.email)
         val token = signInDto.token
 
         val accessToken: String = jwtTokenProvider.generateAccessToken(gAuthUserInfo.email, role)
@@ -42,11 +41,7 @@ class SignInServiceImpl(
         val accessExp: ZonedDateTime = jwtTokenProvider.accessExpiredTime
         val refreshExp: ZonedDateTime = jwtTokenProvider.refreshExpiredTime
 
-        if(role == Role.ROLE_ADMIN) {
-            createAdminOrRefreshToken(gAuthUserInfo, refreshToken, token)
-        } else {
-            createUserOrRefreshToken(gAuthUserInfo, refreshToken, token)
-        }
+        createUserByRoleOrRefreshToken(gAuthUserInfo, refreshToken, token, role)
 
         return SignInResponseDto(
             accessToken = accessToken,
@@ -56,7 +51,7 @@ class SignInServiceImpl(
         )
     }
 
-    private fun getRoleByGauthInfo(role: String, email: String): Role {
+    private fun getRoleByGAuthInfo(role: String, email: String): Role {
         val user = userRepository.findByEmail(email) ?:
         return when (role) {
             "ROLE_STUDENT" -> Role.ROLE_STUDENT
@@ -68,22 +63,10 @@ class SignInServiceImpl(
         return Role.ROLE_STUDENT
     }
 
-    private fun createUserOrRefreshToken(gAuthUserInfo: GAuthUserInfo, refreshToken: String, token: String?) {
+    private fun createUserByRoleOrRefreshToken(gAuthUserInfo: GAuthUserInfo, refreshToken: String, token: String?, role: Role) {
         val userInfo = userRepository.findByEmail(gAuthUserInfo.email)
-        if (userInfo == null) {
-            authUtil.saveNewUser(gAuthUserInfo, refreshToken, token)
-        } else {
-            authUtil.saveNewRefreshToken(userInfo, refreshToken, token)
-        }
-    }
+            ?: authUtil.saveNewUser(gAuthUserInfo, refreshToken, token, role)
 
-    private fun createAdminOrRefreshToken(gAuthUserInfo: GAuthUserInfo, refreshToken: String, token: String?) {
-        val adminInfo = userRepository.findByEmail(gAuthUserInfo.email)
-        if (adminInfo == null) {
-            authUtil.saveNewAdmin(gAuthUserInfo, refreshToken, token)
-        } else {
-            authUtil.saveNewRefreshToken(adminInfo, refreshToken, token)
-        }
+        authUtil.saveRefreshToken(userInfo, refreshToken, token)
     }
-
 }

--- a/src/main/kotlin/com/msg/gcms/domain/auth/service/impl/SignInServiceImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/auth/service/impl/SignInServiceImpl.kt
@@ -34,7 +34,7 @@ class SignInServiceImpl(
         )
         val gAuthUserInfo: GAuthUserInfo = gAuth.getUserInfo(gAuthToken.accessToken)
         val role = getRoleByGAuthInfo(gAuthUserInfo.role, gAuthUserInfo.email)
-        val token = signInDto.token
+        val token = signInDto.token ?: ""
 
         val accessToken: String = jwtTokenProvider.generateAccessToken(gAuthUserInfo.email, role)
         val refreshToken: String = jwtTokenProvider.generateRefreshToken(gAuthUserInfo.email, role)
@@ -63,7 +63,7 @@ class SignInServiceImpl(
         return Role.ROLE_STUDENT
     }
 
-    private fun createUserByRoleOrRefreshToken(gAuthUserInfo: GAuthUserInfo, refreshToken: String, token: String?, role: Role) {
+    private fun createUserByRoleOrRefreshToken(gAuthUserInfo: GAuthUserInfo, refreshToken: String, token: String, role: Role) {
         val userInfo = userRepository.findByEmail(gAuthUserInfo.email)
             ?: authUtil.saveNewUser(gAuthUserInfo, refreshToken, token, role)
 

--- a/src/main/kotlin/com/msg/gcms/domain/auth/util/AuthConverter.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/auth/util/AuthConverter.kt
@@ -1,5 +1,6 @@
 package com.msg.gcms.domain.auth.util
 
+import com.msg.gcms.domain.auth.domain.Role
 import com.msg.gcms.domain.auth.domain.entity.RefreshToken
 import com.msg.gcms.domain.auth.presentation.data.dto.DeviceTokenDto
 import com.msg.gcms.domain.auth.presentation.data.dto.SignInDto
@@ -13,10 +14,7 @@ interface AuthConverter {
 
     fun toDto(signInRequestDto: SignInRequestDto): SignInDto
     fun toDto(deviceTokenRequest: DeviceTokenRequest): DeviceTokenDto
-
-    fun toEntity(gAuthUserInfo: GAuthUserInfo): User
-
-    fun toAdminEntity(gAuthUserInfo: GAuthUserInfo): User
+    fun toEntity(gAuthUserInfo: GAuthUserInfo, role: Role): User
 
     fun toEntity(userInfo: User, refreshToken: String): RefreshToken
     fun toEntity(userId: UUID?, refreshToken: String): RefreshToken

--- a/src/main/kotlin/com/msg/gcms/domain/auth/util/AuthUtil.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/auth/util/AuthUtil.kt
@@ -1,5 +1,6 @@
 package com.msg.gcms.domain.auth.util
 
+import com.msg.gcms.domain.auth.domain.Role
 import com.msg.gcms.domain.auth.domain.entity.RefreshToken
 import com.msg.gcms.domain.user.domain.entity.User
 import gauth.GAuthUserInfo
@@ -7,9 +8,6 @@ import gauth.GAuthUserInfo
 
 interface AuthUtil {
 
-    fun saveNewUser(gAuthUserInfo: GAuthUserInfo, refreshToken: String, token: String?)
-
-    fun saveNewAdmin(gAuthUserInfo: GAuthUserInfo, refreshToken: String, token: String?)
-
-    fun saveNewRefreshToken(userInfo: User, refreshToken: String, token: String?): RefreshToken
+    fun saveNewUser(gAuthUserInfo: GAuthUserInfo, refreshToken: String, token: String?, role: Role): User
+    fun saveRefreshToken(userInfo: User, refreshToken: String, token: String?): RefreshToken
 }

--- a/src/main/kotlin/com/msg/gcms/domain/auth/util/AuthUtil.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/auth/util/AuthUtil.kt
@@ -8,6 +8,6 @@ import gauth.GAuthUserInfo
 
 interface AuthUtil {
 
-    fun saveNewUser(gAuthUserInfo: GAuthUserInfo, refreshToken: String, token: String?, role: Role): User
-    fun saveRefreshToken(userInfo: User, refreshToken: String, token: String?): RefreshToken
+    fun saveNewUser(gAuthUserInfo: GAuthUserInfo, refreshToken: String, token: String, role: Role): User
+    fun saveRefreshToken(userInfo: User, refreshToken: String, token: String): RefreshToken
 }

--- a/src/main/kotlin/com/msg/gcms/domain/auth/util/impl/AuthConverterImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/auth/util/impl/AuthConverterImpl.kt
@@ -23,28 +23,15 @@ class AuthConverterImpl : AuthConverter {
     override fun toDto(deviceTokenRequest: DeviceTokenRequest): DeviceTokenDto =
         DeviceTokenDto(deviceTokenRequest.token)
 
-
-    override fun toEntity(gAuthUserInfo: GAuthUserInfo): User =
+    override fun toEntity(gAuthUserInfo: GAuthUserInfo, role: Role): User =
         User(
             id = UUID.randomUUID(),
             email = gAuthUserInfo.email,
             nickname = gAuthUserInfo.name,
-            grade = gAuthUserInfo.grade,
-            classNum = gAuthUserInfo.classNum,
-            number = gAuthUserInfo.num,
-            roles = mutableListOf(Role.ROLE_STUDENT),
-            profileImg = gAuthUserInfo.profileUrl,
-        )
-
-    override fun toAdminEntity(gAuthUserInfo: GAuthUserInfo): User =
-        User(
-            id = UUID.randomUUID(),
-            email = gAuthUserInfo.email,
-            nickname = gAuthUserInfo.name,
-            grade = 0,
-            classNum = 0,
-            number = 0,
-            roles = mutableListOf(Role.ROLE_ADMIN),
+            grade = gAuthUserInfo.grade ?: 0,
+            classNum = gAuthUserInfo.classNum ?: 0,
+            number = gAuthUserInfo.num ?: 0,
+            roles = mutableListOf(role),
             profileImg = gAuthUserInfo.profileUrl,
         )
 

--- a/src/main/kotlin/com/msg/gcms/domain/auth/util/impl/AuthUtilImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/auth/util/impl/AuthUtilImpl.kt
@@ -1,5 +1,6 @@
 package com.msg.gcms.domain.auth.util.impl
 
+import com.msg.gcms.domain.auth.domain.Role
 import com.msg.gcms.domain.auth.domain.entity.RefreshToken
 import com.msg.gcms.domain.auth.domain.repository.RefreshTokenRepository
 import com.msg.gcms.domain.auth.util.AuthConverter
@@ -19,19 +20,15 @@ class AuthUtilImpl(
     private val deviceTokenRepository: DeviceTokenRepository
 ) : AuthUtil {
 
-    override fun saveNewUser(gAuthUserInfo: GAuthUserInfo, refreshToken: String, token: String?) {
-        val signInUserInfo: User = authConverter.toEntity(gAuthUserInfo)
+    override fun saveNewUser(gAuthUserInfo: GAuthUserInfo, refreshToken: String, token: String?, role: Role): User {
+
+        val user = authConverter.toEntity(gAuthUserInfo, role)
             .let { userRepository.save(it) }
-        saveNewRefreshToken(signInUserInfo, refreshToken, token)
+
+        return user
     }
 
-    override fun saveNewAdmin(gAuthUserInfo: GAuthUserInfo, refreshToken: String, token: String?) {
-        val signInAdminInfo: User = authConverter.toAdminEntity(gAuthUserInfo)
-            .let { userRepository.save(it) }
-        saveNewRefreshToken(signInAdminInfo, refreshToken, token)
-    }
-
-    override fun saveNewRefreshToken(userInfo: User, refreshToken: String, token: String?): RefreshToken {
+    override fun saveRefreshToken(userInfo: User, refreshToken: String, token: String?): RefreshToken {
         deviceTokenRepository.save(DeviceToken(userInfo.id, userInfo, token ?: ""))
         return authConverter.toEntity(userInfo, refreshToken)
             .let { refreshTokenRepository.save(it) }

--- a/src/main/kotlin/com/msg/gcms/domain/auth/util/impl/AuthUtilImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/auth/util/impl/AuthUtilImpl.kt
@@ -29,7 +29,13 @@ class AuthUtilImpl(
     }
 
     override fun saveRefreshToken(userInfo: User, refreshToken: String, token: String?): RefreshToken {
-        deviceTokenRepository.save(DeviceToken(userInfo.id, userInfo, token ?: ""))
+        deviceTokenRepository.save(
+            DeviceToken(
+               userId = userInfo.id,
+               user = userInfo, 
+               token = token ?: ""
+           )
+       )
         return authConverter.toEntity(userInfo, refreshToken)
             .let { refreshTokenRepository.save(it) }
     }

--- a/src/main/kotlin/com/msg/gcms/domain/auth/util/impl/AuthUtilImpl.kt
+++ b/src/main/kotlin/com/msg/gcms/domain/auth/util/impl/AuthUtilImpl.kt
@@ -20,20 +20,19 @@ class AuthUtilImpl(
     private val deviceTokenRepository: DeviceTokenRepository
 ) : AuthUtil {
 
-    override fun saveNewUser(gAuthUserInfo: GAuthUserInfo, refreshToken: String, token: String?, role: Role): User {
-
+    override fun saveNewUser(gAuthUserInfo: GAuthUserInfo, refreshToken: String, token: String, role: Role): User {
         val user = authConverter.toEntity(gAuthUserInfo, role)
             .let { userRepository.save(it) }
 
         return user
     }
 
-    override fun saveRefreshToken(userInfo: User, refreshToken: String, token: String?): RefreshToken {
+    override fun saveRefreshToken(userInfo: User, refreshToken: String, token: String): RefreshToken {
         deviceTokenRepository.save(
             DeviceToken(
                userId = userInfo.id,
                user = userInfo, 
-               token = token ?: ""
+               token = token
            )
        )
         return authConverter.toEntity(userInfo, refreshToken)

--- a/src/test/kotlin/com/msg/gcms/domain/auth/service/SignInServiceTest.kt
+++ b/src/test/kotlin/com/msg/gcms/domain/auth/service/SignInServiceTest.kt
@@ -13,7 +13,6 @@ import com.msg.gcms.domain.user.domain.repository.DeviceTokenRepository
 import com.msg.gcms.domain.user.domain.repository.UserRepository
 import com.msg.gcms.global.gauth.properties.GAuthProperties
 import com.msg.gcms.global.security.jwt.JwtTokenProvider
-import com.msg.gcms.global.util.MessageSendUtil
 import gauth.GAuth
 import gauth.GAuthToken
 import gauth.GAuthUserInfo
@@ -102,7 +101,7 @@ class SignInServiceTest : BehaviorSpec({
         )
 
         every {
-            authUtil.saveNewRefreshToken(userInfo = user, refreshToken = refreshToken, "")
+            authUtil.saveRefreshToken(userInfo = user, refreshToken = refreshToken, "")
         } returns refreshTokenEntity
 
         val signInDto = SignInDto(
@@ -128,10 +127,6 @@ class SignInServiceTest : BehaviorSpec({
         every {
             tokenProvider.refreshExpiredTime
         } returns refreshExp
-
-        every {
-            authConverter.toEntity(gAuthUserInfo)
-        } returns user
 
         every {
             authConverter.toEntity(user, refreshToken)


### PR DESCRIPTION
## 💡 배경 및 개요

로그인 코드의 개선점이 보여 리팩토링을 진행하게 되었습니다

Resolves: #{330}

## 📃 작업내용

authConverter와 authUtil의 중복되는 코드를 제거하고 필요하지 않은 분기문도 제거했습니다

## 🙋‍♂️ 리뷰노트

함수 단위로 분리된 비즈니스 로직들을 하나의 함수에서 처리하고 싶었지만 책임단위로 분리하는 것도 나쁘지 않은것 같다는 생각이 들어 기존의 구조를 유지하였습니다

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타